### PR TITLE
Add tests for remaining database.py functions (phase_as_value + make_packet)

### DIFF
--- a/engine/database.py
+++ b/engine/database.py
@@ -93,7 +93,7 @@ class DataBase:
         
         acc = []
         for i in self.get_data("acceleration"):
-            acc += str(i)
+            acc.append(str(i))
 
         temp_n_dist = "00.0"
         temp_rot = "00.00"

--- a/tests/compilation_tests/database_test.py
+++ b/tests/compilation_tests/database_test.py
@@ -170,7 +170,16 @@ class TestDataBase(unittest.TestCase):
             db_robot_phase.update_data("phase", phases[i])
 
     def test_make_packet(self):
-        pass
+        expected_outputs = [
+            "phase:1;p_weight:00.0;acc:0.00,0.00,0.00;n_dist:00.0;rot:00.00;last_n:000.00,000.00;vel:0.00;next_n:000.00,000.00;coord:000.00,000.00,000.00;batt:100;ctrl:1",
+            "phase:2;p_weight:02.0;acc:4.25,3.20,0.10;n_dist:00.0;rot:00.00;last_n:000.00,000.00;vel:0.00;next_n:000.00,000.00;coord:010.00,020.00,050.00;batt:098;ctrl:1",
+            "phase:1;p_weight:03.0;acc:0.50,0.20,0.30;n_dist:00.0;rot:00.00;last_n:000.00,000.00;vel:0.00;next_n:000.00,000.00;coord:000.00,000.00,000.00;batt:046;ctrl:1",
+            ]
+
+        testcases = [(expected_outputs[0], self.db_default), (expected_outputs[1], self.db_initial), (expected_outputs[2], self.db_one_param)]
+
+        for expected_ans, database in testcases:
+            self.assertEqual(expected_ans, database.make_packet())
 
 
 if __name__ == '__main__':

--- a/tests/compilation_tests/database_test.py
+++ b/tests/compilation_tests/database_test.py
@@ -1,3 +1,4 @@
+from matplotlib.mlab import phase_spectrum
 import numpy as np
 
 from engine.database import DataBase
@@ -157,6 +158,19 @@ class TestDataBase(unittest.TestCase):
                     self.assertEqual(ans[2], data[2], name)
                 else:
                     self.assertEqual(ans, database.get_data(name), name)
+
+    def test_phase_as_value(self):
+        robot_phase = Robot(x_pos= 0, y_pos =0, heading =0, epsilon =0, max_v =0, 
+    radius =0, is_sim=True)
+        db_robot_phase = DataBase(robot_phase)
+        phases = list(Phase)
+        num_phases = len(phases)
+        for i in range(1, num_phases):
+            self.assertEqual(i, db_robot_phase.phase_as_value())
+            db_robot_phase.update_data("phase", phases[i])
+
+    def test_make_packet(self):
+        pass
 
 
 if __name__ == '__main__':

--- a/tests/compilation_tests/database_test.py
+++ b/tests/compilation_tests/database_test.py
@@ -1,4 +1,3 @@
-from matplotlib.mlab import phase_spectrum
 import numpy as np
 
 from engine.database import DataBase


### PR DESCRIPTION
<!-- Make sure your PR title above ^ is descriptive (e.g. "Changing color of waypoints on Matplotlib graph of robot simulation") -->

<!-- ## References -->
<!-- Add any other external links/references/resources here -->

## Summary
### TLDR: Added tests for `phase_as_value` and `make_packet` in `database.py`. Fixed bug with converting robot acceleration into a string.
<!-- e.g TLDR: Currently, all the waypoints on our Matplotlib popup graph for our robot simulation are all the same color. 
To differentiate between active and inactive nodes, active nodes will be colored blue and inactive nodes will be colored red.
This will allow the user to visually see where the robot plans to go. -->

### Description
<!-- Add a more detailed description here to give your reviewer context. Relevant screenshots. What changes were made? Why did you decide to implement it this way? etc. -->
In order to increase our unit testing, I added some tests for the remaining functions in `database.py`. 

In `test_phase_as_value`, I created a database instance and tests `phase_as_value` against a list of all phase values, updating the phase stored in the database respectively. Made sure to use our enum `Phase` here in case we modify the enum in the future. 

In `test_make_packet`, I created the expected packet (specified in `packet.py`) for each of the global test databases. Note, the test cases for `test_make_packet` can be expanded in the future once we determine how to extract our packet properties from our main mission (e.g. rot, last_n which isn't a direct property of robot atm). I also came across a bug where acceleration was being converted to a string incorrectly since we were adding rather than appending strings to a list & fixed it.

Code Coverage:
Before: 60%
<img width="1084" alt="Screen Shot 2022-10-12 at 7 25 24 PM" src="https://user-images.githubusercontent.com/60713782/195465923-45622646-e073-45ad-9172-ee4d06392c51.png">
After: 100% \o/
<img width="1086" alt="Screen Shot 2022-10-12 at 7 25 38 PM" src="https://user-images.githubusercontent.com/60713782/195465924-49ae14de-2b96-4887-a491-9aba47b5537e.png">

## Test Plan
<!-- How has this been tested? What steps did you take? Please describe in detail how you tested your changes and why it works. -->
Ran `coverage run -m tests.compilation_tests.test_runner` to run our compilation tests and make sure the new tests don't fail
`coverage html `,`open htmlcov/index.html ` to see coverage changes.

## Other
<!-- Add any additional details here (e.g. co-authors). Delete this section if this is not relevant. -->

<!-- Please make sure PRs are small. If not, consider breaking up your PR into multiple PRs.
Feel free to delete comments after you are done. -->
