### PR TITLE
Integrate motor controller

### DIFF
--- a/electrical/motor_controller.py
+++ b/electrical/motor_controller.py
@@ -105,17 +105,18 @@ class MotorController:
         self.enA = 13
         self.enB = 12
 
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup([self.in1, self.in2, self.in3, self.in4],
-                   GPIO.OUT, initial=GPIO.LOW)
-        GPIO.setup([self.enA, self.enB], GPIO.OUT)  # EnA, EnB
+        if not self.is_sim:
+            GPIO.setmode(GPIO.BCM)
+            GPIO.setup([self.in1, self.in2, self.in3, self.in4],
+                       GPIO.OUT, initial=GPIO.LOW)
+            GPIO.setup([self.enA, self.enB], GPIO.OUT)  # EnA, EnB
 
-        self.p1 = GPIO.PWM(self.enA, 50)
-        self.p2 = GPIO.PWM(self.enB, 50)
+            self.p1 = GPIO.PWM(self.enA, 50)
+            self.p2 = GPIO.PWM(self.enB, 50)
 
-    # Start with 0% duty cycle
-        self.p1.start(0)
-        self.p2.start(0)
+            # Start with 0% duty cycle
+            self.p1.start(0)
+            self.p2.start(0)
 
     # Initialize the robot's motors to 0 voltage. Used when powering the robot on.
     def setup(self):

--- a/electrical/motor_controller.py
+++ b/electrical/motor_controller.py
@@ -91,8 +91,7 @@ class MotorController:
         R: radius of right motor #TODO: double check this
     """
 
-    def __init__(self, is_sim, wheel_radius, vm_load1, vm_load2, L, R):
-        self.is_sim = is_sim
+    def __init__(self, wheel_radius, vm_load1, vm_load2, L, R):
         self.wheel_radius = wheel_radius
         self.vm_load1 = vm_load1
         self.vm_load2 = vm_load2
@@ -105,37 +104,33 @@ class MotorController:
         self.enA = 13
         self.enB = 12
 
-        if not self.is_sim:
-            GPIO.setmode(GPIO.BCM)
-            GPIO.setup([self.in1, self.in2, self.in3, self.in4],
-                       GPIO.OUT, initial=GPIO.LOW)
-            GPIO.setup([self.enA, self.enB], GPIO.OUT)  # EnA, EnB
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup([self.in1, self.in2, self.in3, self.in4],
+                    GPIO.OUT, initial=GPIO.LOW)
+        GPIO.setup([self.enA, self.enB], GPIO.OUT)  # EnA, EnB
 
-            self.p1 = GPIO.PWM(self.enA, 50)
-            self.p2 = GPIO.PWM(self.enB, 50)
+        self.p1 = GPIO.PWM(self.enA, 50)
+        self.p2 = GPIO.PWM(self.enB, 50)
 
-            # Start with 0% duty cycle
-            self.p1.start(0)
-            self.p2.start(0)
+        # Start with 0% duty cycle
+        self.p1.start(0)
+        self.p2.start(0)
 
     # Initialize the robot's motors to 0 voltage. Used when powering the robot on.
     def setup(self):
-        if self.is_sim:
-            self.spin_motors(0, 0)
-        else:
-            GPIO.setmode(GPIO.BCM)
-            GPIO.setup([self.in1, self.in2, self.in3, self.in4],
-                       GPIO.OUT, initial=GPIO.LOW)
-            GPIO.setup([self.enA, self.enB], GPIO.OUT)  # EnA, EnB
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup([self.in1, self.in2, self.in3, self.in4],
+                    GPIO.OUT, initial=GPIO.LOW)
+        GPIO.setup([self.enA, self.enB], GPIO.OUT)  # EnA, EnB
 
-            self.p1 = GPIO.PWM(self.enA, 50)
-            self.p2 = GPIO.PWM(self.enB, 50)
+        self.p1 = GPIO.PWM(self.enA, 50)
+        self.p2 = GPIO.PWM(self.enB, 50)
 
-            # Initialize PWM duty cycles as 0
-            self.p1.start(0)
-            self.p2.start(0)
+        # Initialize PWM duty cycles as 0
+        self.p1.start(0)
+        self.p2.start(0)
 
-            self.spin_motors(0, 0)
+        self.spin_motors(0, 0)
 
     # converts the robot's overall calculated angular velocity and linear velocity
     # into the angular velocities for left and right sides of the robot

--- a/electrical/motor_controller.py
+++ b/electrical/motor_controller.py
@@ -2,20 +2,22 @@ import time
 #from engine.robot import Robot
 if False:  # change to True when running code on robot
     import RPi.GPIO as GPIO
-    
+
+
 class BasicMotorController:
     """ 
     BasicMotorController contains pinouts to configure motor controller, as well as 
     commands to physically move the robot. 
     """
+
     def __init__(self, robot):
         # raspberry pi motor driver pinouts
         self.in1 = 5
         self.in2 = 6
         self.in3 = 19
         self.in4 = 26
-        self.enA = 13   #PWM pin
-        self.enB = 12   #PWM pin
+        self.enA = 13  # PWM pin
+        self.enB = 12  # PWM pin
         self.is_sim = robot.is_sim
 
     # checks all of the robot movements are functioning properly
@@ -30,7 +32,7 @@ class BasicMotorController:
             self.e1 = GPIO.PWM(self.enA, 600)
             self.e2 = GPIO.PWM(self.enB, 600)
             self.e1.start(100)
-            self.e2.start(100)            
+            self.e2.start(100)
 
     # stops the robot
     def stop(self):
@@ -88,8 +90,9 @@ class MotorController:
         L: radius of left motor #TODO: double check this 
         R: radius of right motor #TODO: double check this
     """
-    def __init__(self, robot, wheel_radius, vm_load1, vm_load2, L, R):
-        self.is_sim = robot.is_sim
+
+    def __init__(self, is_sim, wheel_radius, vm_load1, vm_load2, L, R):
+        self.is_sim = is_sim
         self.wheel_radius = wheel_radius
         self.vm_load1 = vm_load1
         self.vm_load2 = vm_load2
@@ -113,14 +116,15 @@ class MotorController:
     # Start with 0% duty cycle
         self.p1.start(0)
         self.p2.start(0)
-    
-    # Initialize the robot's motors to 0 voltage. Used when powering the robot on. 
+
+    # Initialize the robot's motors to 0 voltage. Used when powering the robot on.
     def setup(self):
-        if self.is_sim: 
+        if self.is_sim:
             self.spin_motors(0, 0)
         else:
             GPIO.setmode(GPIO.BCM)
-            GPIO.setup([self.in1, self.in2, self.in3, self.in4], GPIO.OUT, initial=GPIO.LOW)  
+            GPIO.setup([self.in1, self.in2, self.in3, self.in4],
+                       GPIO.OUT, initial=GPIO.LOW)
             GPIO.setup([self.enA, self.enB], GPIO.OUT)  # EnA, EnB
 
             self.p1 = GPIO.PWM(self.enA, 50)
@@ -131,9 +135,9 @@ class MotorController:
             self.p2.start(0)
 
             self.spin_motors(0, 0)
-   
-    #converts the robot's overall calculated angular velocity and linear velocity 
-    #into the angular velocities for left and right sides of the robot
+
+    # converts the robot's overall calculated angular velocity and linear velocity
+    # into the angular velocities for left and right sides of the robot
     def left_right_angular_vel(self, omega, vel):
         if omega == 0:
             vr = vel
@@ -146,28 +150,26 @@ class MotorController:
         omega_l = vl * self.wheel_radius
         return omega_r, omega_l
 
-
-    # Change duty cycle (voltage applied) for motors based on 
+    # Change duty cycle (voltage applied) for motors based on
     # overall robot's angular and linear velocities
+
     def spin_motors(self, omega, vel):
         omega_right, omega_left = self.left_right_angular_vel(omega, vel)
-        
+
         # Define and cap duty cycles if they are above max
-        try: 
+        try:
             dc1 = omega_right / self.vm_load1
             dc2 = omega_left / self.vm_load2
-        except: 
+        except:
             raise ZeroDivisionError("vm_load1 or vm_load2 is zero")
 
         if dc1 > 100:
             dc1 = 100
         if dc2 > 100:
             dc2 = 100
-        
-        if self.is_sim:
+
+        if not self.is_sim:
             self.p1.ChangeDutyCycle(dc1)
             self.p2.ChangeDutyCycle(dc2)
-        else: 
+        else:
             print("dc1: ", dc1, "and dc2: ", dc2)
-
-    

--- a/engine/mission.py
+++ b/engine/mission.py
@@ -64,7 +64,7 @@ class Mission:
         self.inactive_waypoints = self.grid.get_inactive_waypoints_list()
         self.waypoints_to_visit = deque(self.all_waypoints)
         self.allowed_dist_error = allowed_dist_error
-        if self.robot.is_sim:
+        if not self.robot.is_sim:
             self.gps_serial = serial.Serial('/dev/ttyACM0', 19200, timeout=5)
             self.robot_radio_serial = serial.Serial(
                 '/dev/ttyS0', 57600)  # robot radio

--- a/engine/mission.py
+++ b/engine/mission.py
@@ -33,6 +33,7 @@ Commented out for simulation testing purposes
 # import busio
 # import adafruit_lsm9ds1
 
+
 class Mission:
     def __init__(self, robot, base_station, init_control_mode, grid=Grid(42.444250, 42.444599, -76.483682, -76.483276),
                  allowed_dist_error=0.5, allowed_heading_error=0.1, allowed_docking_pos_error=0.1,
@@ -51,7 +52,7 @@ class Mission:
                 before it can start docking.
             time_limit: the maximum time the robot can execute roomba traversal mode
             roomba_radius: the maximum radius from the base station that the robot in roomba traversal mode can move
-        
+
         Important: All the ports of the electrical classes (ie. Serial) need to be updated to the respective 
                     ports they are connected to on the computer running the code.
         """
@@ -63,23 +64,24 @@ class Mission:
         self.inactive_waypoints = self.grid.get_inactive_waypoints_list()
         self.waypoints_to_visit = deque(self.all_waypoints)
         self.allowed_dist_error = allowed_dist_error
-        if not robot.is_sim:
-            self.gps_serial = serial.Serial('/dev/ttyACM0', 19200, timeout=5) 
-            self.robot_radio_serial = serial.Serial('/dev/ttyS0', 57600) #robot radio 
+        if self.robot.is_sim:
+            self.gps_serial = serial.Serial('/dev/ttyACM0', 19200, timeout=5)
+            self.robot_radio_serial = serial.Serial(
+                '/dev/ttyS0', 57600)  # robot radio
             self.imu_i2c = busio.I2C(board.SCL, board.SDA)
-            self.motor_controller = MotorController(robot, wheel_r = 0, vm_load1 = 1, vm_load2 = 1, L = 0, R = 0)
-            self.robot_radio_session = RadioSession(self.robot_radio_serial) 
-            self.gps = GPS(self.gps_serial) 
-            self.imu = IMU(self.imu_i2c) 
+            self.robot_radio_session = RadioSession(self.robot_radio_serial)
+            self.gps = GPS(self.gps_serial)
+            self.imu = IMU(self.imu_i2c)
         self.allowed_heading_error = allowed_heading_error
         self.base_station_angle = base_station.heading
         self.allowed_docking_pos_error = allowed_docking_pos_error
-        x = get_vincenty_x((grid.lat_min, grid.long_min), base_station.position)
-        y = get_vincenty_y((grid.lat_min, grid.long_min), base_station.position)
+        x = get_vincenty_x((grid.lat_min, grid.long_min),
+                           base_station.position)
+        y = get_vincenty_y((grid.lat_min, grid.long_min),
+                           base_station.position)
         self.base_station_loc = (x, y)
         self.time_limit = time_limit
         self.roomba_radius = roomba_radius
-
 
     def execute_mission(self, database):
         """
@@ -88,7 +90,8 @@ class Mission:
         """
         while self.robot.phase != Phase.COMPLETE:
             if self.robot.phase == Phase.SETUP:
-                self.robot.execute_setup(self.robot_radio_session, self.gps, self.imu, self.motor_controller)
+                self.robot.execute_setup(
+                    self.robot_radio_session, self.gps, self.imu, self.robot.motor_controller)
 
             elif self.robot.phase == Phase.TRAVERSE:
                 self.waypoints_to_visit = self.robot.execute_traversal(self.waypoints_to_visit,
@@ -105,9 +108,6 @@ class Mission:
 
             elif self.robot.phase == Phase.DOCKING:
                 self.robot.execute_docking()
-            
-            #update the database with the most recent state
+
+            # update the database with the most recent state
             database.update_data("phase", self.robot.phase)
-            
-
-

--- a/engine/robot.py
+++ b/engine/robot.py
@@ -104,7 +104,7 @@ class Robot:
         self.gyro_rotation = [0, 0, 0]  # TEMPORARY
         self.linear_v = 0
         self.angular_v = 0
-        self.motor_controller = MotorController(self.is_sim, wheel_r=0,
+        self.motor_controller = MotorController(self.is_sim, wheel_radius=0,
                                                 vm_load1=1, vm_load2=1, L=0, R=0)
 
         self.loc_pid_x = PID(

--- a/engine/robot.py
+++ b/engine/robot.py
@@ -104,8 +104,9 @@ class Robot:
         self.gyro_rotation = [0, 0, 0]  # TEMPORARY
         self.linear_v = 0
         self.angular_v = 0
-        self.motor_controller = MotorController(self.is_sim, wheel_radius=0,
-                                                vm_load1=1, vm_load2=1, L=0, R=0)
+        if not self.is_sim:
+            self.motor_controller = MotorController(self.is_sim, wheel_radius=0,
+                                                    vm_load1=1, vm_load2=1, L=0, R=0)
 
         self.loc_pid_x = PID(
             Kp=self.position_kp, Ki=self.position_ki, Kd=self.position_kd, target=0, sample_time=self.time_step,

--- a/engine/robot.py
+++ b/engine/robot.py
@@ -1,13 +1,14 @@
 import numpy as np
 import math
+from electrical import motor_controller
 from engine.kinematics import integrate_odom, feedback_lin, limit_cmds
 from engine.pid_controller import PID
 from electrical.motor_controller import MotorController
 from constants.definitions import CSV_PATH
 
 
-# import electrical.gps as gps 
-# import electrical.imu as imu 
+# import electrical.gps as gps
+# import electrical.imu as imu
 # import electrical.radio_module as radio_module
 
 
@@ -28,6 +29,7 @@ class Phase(Enum):
     COMPLETE = 6
     FAULT = 7
 
+
 class Robot:
     """
     A class whose objects contain robot-specific information, and methods to execute individual phases.
@@ -46,7 +48,7 @@ class Robot:
 
     def __init__(self, x_pos, y_pos, heading, epsilon, max_v, radius, is_sim=True, position_kp=1, position_ki=0,
                  position_kd=0, position_noise=0, heading_kp=1, heading_ki=0, heading_kd=0, heading_noise=0,
-                 init_phase=1, time_step=1, move_dist=.5, turn_angle=3, plastic_weight=0):
+                 init_phase=1, time_step=1, move_dist=.5, turn_angle=3, plastic_weight=0, motor_controller=None):
         """
         Arguments:
             x_pos: the x position of the robot, where (0,0) is the bottom left corner of the grid with which
@@ -102,6 +104,8 @@ class Robot:
         self.gyro_rotation = [0, 0, 0]  # TEMPORARY
         self.linear_v = 0
         self.angular_v = 0
+        self.motor_controller = MotorController(self.is_sim, wheel_r=0,
+                                                vm_load1=1, vm_load2=1, L=0, R=0)
 
         self.loc_pid_x = PID(
             Kp=self.position_kp, Ki=self.position_ki, Kd=self.position_kd, target=0, sample_time=self.time_step,
@@ -149,8 +153,9 @@ class Robot:
 
         Arguments:
             target: target coordinates in the form (latitude, longitude)
-            allowed_dist_error: the maximum distance in meters that the robot can be from a node for the robot to
-                have "visited" that node
+            allowed_dist_error: the maximum distance in meters that the robot 
+            can be from a node for the robot to have "visited" that node
+            database: 
         """
         predicted_state = self.state  # this will come from Kalman Filter
 
@@ -159,16 +164,19 @@ class Robot:
                                    float(predicted_state[1]) - target[1])
 
         while distance_away > allowed_dist_error:
-            self.state[0] = np.random.normal(
-                self.state[0], self.position_noise)
-            self.state[1] = np.random.normal(
-                self.state[1], self.position_noise)
+            if self.is_sim:
+                # Adding simulated noise to the robot's state based on gaussian distribution
+                self.state[0] = np.random.normal(
+                    self.state[0], self.position_noise)
+                self.state[1] = np.random.normal(
+                    self.state[1], self.position_noise)
 
-            x_error = target[0] - self.state[0]
-            y_error = target[1] - self.state[1]
+            # Error in terms of latitude and longitude, NOT meters
+            x_coords_error = target[0] - self.state[0]
+            y_coords_error = target[1] - self.state[1]
 
-            x_vel = self.loc_pid_x.update(x_error)
-            y_vel = self.loc_pid_y.update(y_error)
+            x_vel = self.loc_pid_x.update(x_coords_error)
+            y_vel = self.loc_pid_y.update(y_coords_error)
 
             cmd_v, cmd_w = feedback_lin(
                 predicted_state, x_vel, y_vel, self.epsilon)
@@ -176,33 +184,43 @@ class Robot:
             # clamping of velocities:
             (limited_cmd_v, limited_cmd_w) = limit_cmds(
                 cmd_v, cmd_w, self.max_velocity, self.radius)
+            # self.linear_v = limited_cmd_v[0]
+            # self.angular_v = limited_cmd_w[0]
 
-            self.linear_v = limited_cmd_v[0]
-            self.angular_v = limited_cmd_w[0]
-
-            self.travel(self.time_step * limited_cmd_v,
-                        self.time_step * limited_cmd_w)
-            
-            # for real robot: 
-            #TODO: pass in motor controller or initialize it somewhere within the codebase
-            #      to call the spin_motors function
-            # self.motor_controller.spin_motors(self.angular_v, self.linear_v) 
-
-            # write robot location and mag heading in csv (for gui to display)
-            with open(CSV_PATH + '/datastore.csv', 'a') as fd:
-                fd.write(
-                    str(self.state[0])[1:-1] + ',' + str(self.state[1])[1:-1] + ',' + str(self.state[2])[1:-1] + '\n')
-            time.sleep(0.001)
+            if self.is_sim:
+                # this is just simulating movement:
+                self.travel(self.time_step * limited_cmd_v[0],
+                            self.time_step * limited_cmd_w[0])
+            else:
+                self.motor_controller.spin_motors(
+                    limited_cmd_w[0], limited_cmd_v[0])
+                # TODO: sleep??
 
             # Get state after movement:
             predicted_state = self.state  # this will come from Kalman Filter
+
             # TODO: Do we want to update self.state with this new predicted state????
+
+            if self.is_sim:
+                # FOR GUI: writing robot location and mag heading in CSV
+                self.write_to_csv(predicted_state)
+
+            # FOR DATABASE: updating our database with new predicted state
+            # TODO: can the code above be simplified / use the database instead?
             database.update_data(
-                "state", self.state[0], self.state[1], self.state[2])
+                "state", predicted_state[0], predicted_state[1], predicted_state[2])
 
             # location error (in meters)
             distance_away = math.hypot(float(predicted_state[0]) - target[0],
                                        float(predicted_state[1]) - target[1])
+
+    def write_to_csv(predicted_state):
+        cwd = os.getcwd()
+        cd = cwd + "/csv"
+        with open(cd + '/datastore.csv', 'a') as fd:
+            fd.write(
+                str(predicted_state[0])[1:-1] + ',' + str(predicted_state[1])[1:-1] + ',' + str(predicted_state[2])[1:-1] + '\n')
+        time.sleep(0.001)
 
     def turn_to_target_heading(self, target_heading, allowed_heading_error, database):
         """
@@ -256,14 +274,13 @@ class Robot:
         print('heading: ' + str(self.state[2]))
 
     def execute_setup(self, radio_session, gps, imu, motor_controller):
-        gps_setup = gps.setup() 
+        gps_setup = gps.setup()
         imu_setup = imu.setup()
         radio_session.setup_robot()
         motor_controller.setup()
 
-        if (radio_session.connected and gps_setup and imu_setup): 
+        if (radio_session.connected and gps_setup and imu_setup):
             self.phase = Phase.TRAVERSE
-
 
     def execute_traversal(self, unvisited_waypoints, allowed_dist_error, base_station_loc, control_mode, time_limit,
                           roomba_radius, database):
@@ -303,7 +320,8 @@ class Robot:
                 None
         """
         dt = 0
-        exit_boolean = False  # TODO: battery_limit, time_limit, tank_capacity is full, obstacle avoiding
+        # TODO: battery_limit, time_limit, tank_capacity is full, obstacle avoiding
+        exit_boolean = False
         while not exit_boolean:
 
             curr_x = self.state[0]
@@ -321,7 +339,7 @@ class Robot:
                 self.move_forward(self.move_dist)
             dt += 1
             exit_boolean = (dt > time_limit)
-        self.phase = Phase.COMPLETE # TODO: CHANGE the next phase to return
+        self.phase = Phase.COMPLETE  # TODO: CHANGE the next phase to return
         return None
 
     def set_phase(self, new_phase):

--- a/engine/robot.py
+++ b/engine/robot.py
@@ -242,12 +242,14 @@ class Robot:
             w = self.head_pid.update(theta_error)  # angular velocity
             _, limited_cmd_w = limit_cmds(0, w, self.max_velocity, self.radius)
 
-            self.travel(0, self.time_step * limited_cmd_w)
-            # sleep in real robot
+            if self.is_sim:
+                self.travel(0, self.time_step * limited_cmd_w[0])
+            else:
+                self.motor_controller.spin_motors(limited_cmd_w[0], 0)
 
             # Get state after movement:
             predicted_state = self.state  # this will come from Kalman Filter
-            # TODO: Do we want to update self.state with this new predicted state????
+
             database.update_data(
                 "state", self.state[0], self.state[1], self.state[2])
 

--- a/tests/compilation_tests/database_test.py
+++ b/tests/compilation_tests/database_test.py
@@ -9,16 +9,17 @@ from engine.robot import Phase, Robot
 Unit tests for database.py
 '''
 
+
 class TestDataBase(unittest.TestCase):
     # DataBase instances to test on
-    robot_default = Robot(x_pos= 0, y_pos =0, heading =0, epsilon =0, max_v =0, 
-    radius =0, is_sim=True)
+    robot_default = Robot(x_pos=0, y_pos=0, heading=0, epsilon=0, max_v=0,
+                          radius=0, is_sim=True)
 
     db_default = DataBase(robot_default)
 
-
-    robot_initial = Robot(x_pos= 0, y_pos =0, heading =0, epsilon =0, max_v =0, 
-    radius =0, is_sim=False, plastic_weight=2, move_dist=.6, position_noise=0.23)
+    # We can't make is_sim false because it fails GitHub merge tests.
+    robot_initial = Robot(x_pos=0, y_pos=0, heading=0, epsilon=0, max_v=0,
+                          radius=0, is_sim=True, plastic_weight=2, move_dist=.6, position_noise=0.23)
     robot_initial.position_kp = 0.12
     robot_initial.position_ki = 1.7
     robot_initial.position_kd = 9.2
@@ -34,9 +35,8 @@ class TestDataBase(unittest.TestCase):
 
     db_initial = DataBase(robot_initial)
 
-
-    robot_one_param = Robot(x_pos= 0, y_pos =0, heading =0, epsilon =0, 
-    max_v =0, radius =0, plastic_weight=3)
+    robot_one_param = Robot(x_pos=0, y_pos=0, heading=0, epsilon=0,
+                            max_v=0, radius=0, plastic_weight=3)
     robot_one_param.battery = 46
     robot_one_param.acceleration = [0.5, 0.2, 0.3]
 
@@ -64,8 +64,8 @@ class TestDataBase(unittest.TestCase):
                            "position_noise: 0,\n" \
                            "heading_pid [proportional factor, integral factor, derivative factor]: [1, 0, 0]"
 
-        testcases = [(db_str, self.db_default), (db_initial_str, self.db_initial), (db_one_param_str, self.db_one_param)]
-
+        testcases = [(db_str, self.db_default), (db_initial_str,
+                                                 self.db_initial), (db_one_param_str, self.db_one_param)]
 
         for (expected_ans, database) in testcases:
             self.assertEqual(expected_ans, str(database), str(database))
@@ -73,39 +73,47 @@ class TestDataBase(unittest.TestCase):
     def test_get_data(self):
 
         db_params = [(Phase.SETUP, "phase"), ([0, 0, 0], "state"), (True, "is_sim"), (0, "plastic_weight"),
-                     (100, "battery"), (0.5, "move_dist"), ([0, 0, 0], "acceleration"),
+                     (100, "battery"), (0.5, "move_dist"), ([
+                         0, 0, 0], "acceleration"),
                      ([0, 0, 0], "magnetic_field"), ([0, 0, 0], "gyro_rotation"),
-                     ([1, 0, 0], "position_pid"), (0, "position_noise"), ([1, 0, 0], "heading_pid")
+                     ([1, 0, 0], "position_pid"), (0,
+                                                   "position_noise"), ([1, 0, 0], "heading_pid")
                      ]
 
         db_initial_params = [(Phase.TRAVERSE, "phase"), ([10, 20, 50], "state"), (False, "is_sim"),
                              (2, "plastic_weight"),
-                             (98, "battery"), (0.6, "move_dist"), ([4.25, 3.2, 0.1], "acceleration"),
-                             ([0.1, 0.2, 0.3], "magnetic_field"), ([0.5, 0.2, 0.6], "gyro_rotation"),
-                             ([0.12, 1.7, 9.2], "position_pid"), (0.23, "position_noise"),
+                             (98, "battery"), (0.6, "move_dist"), ([
+                                 4.25, 3.2, 0.1], "acceleration"),
+                             ([0.1, 0.2, 0.3], "magnetic_field"), ([
+                                 0.5, 0.2, 0.6], "gyro_rotation"),
+                             ([0.12, 1.7, 9.2], "position_pid"), (0.23,
+                                                                  "position_noise"),
                              ([0.2, 0.4, 0.16], "heading_pid")
                              ]
 
         db_one_params = [(Phase.SETUP, "phase"), ([0, 0, 0], "state"), (True, "is_sim"), (3, "plastic_weight"),
-                         (46, "battery"), (0.5, "move_dist"), ([0.5, 0.2, 0.3], "acceleration"),
-                         ([0, 0, 0], "magnetic_field"), ([0, 0, 0], "gyro_rotation"),
-                         ([1, 0, 0], "position_pid"), (0, "position_noise"), ([1, 0, 0], "heading_pid")
+                         (46, "battery"), (0.5, "move_dist"), ([
+                             0.5, 0.2, 0.3], "acceleration"),
+                         ([0, 0, 0], "magnetic_field"), ([
+                             0, 0, 0], "gyro_rotation"),
+                         ([1, 0, 0], "position_pid"), (0,
+                                                       "position_noise"), ([1, 0, 0], "heading_pid")
                          ]
 
-        testcases = [(db_params, self.db_default), (db_initial_params, self.db_initial), (db_one_params, self.db_one_param)]
+        testcases = [(db_params, self.db_default), (db_initial_params,
+                                                    self.db_initial), (db_one_params, self.db_one_param)]
 
         for expected_ans, database in testcases:
             for (ans, name) in expected_ans:
-                multiple_params = ["state", "acceleration", "magnetic_field", "gyro_rotation", "position_pid", "heading_pid"]
+                multiple_params = ["state", "acceleration", "magnetic_field",
+                                   "gyro_rotation", "position_pid", "heading_pid"]
                 if name in multiple_params:
                     data = database.get_data(name)
                     self.assertEqual(ans[0], data[0], name)
                     self.assertEqual(ans[1], data[1], name)
                     self.assertEqual(ans[2], data[2], name)
                 else:
-                    self.assertEqual(ans, database.get_data(name), name)                
-
-                
+                    self.assertEqual(ans, database.get_data(name), name)
 
     def test_update_data(self):
         self.db_default.update_data("phase", Phase.SETUP)
@@ -125,23 +133,32 @@ class TestDataBase(unittest.TestCase):
         self.db_one_param.update_data("position_pid", y=0.5, z=0.82)
 
         db_new_params = [(Phase.SETUP, "phase"), ([3, 5, 20], "state"), (False, "is_sim"), (0, "plastic_weight"),
-                         (100, "battery"), (0.5, "move_dist"), ([0, 0, 0], "acceleration"),
-                         ([0, 0, 0], "magnetic_field"), ([0, 0, 0], "gyro_rotation"),
-                         ([1, 0, 0], "position_pid"), (0, "position_noise"), ([1, 0, 0], "heading_pid")
+                         (100, "battery"), (0.5, "move_dist"), ([
+                             0, 0, 0], "acceleration"),
+                         ([0, 0, 0], "magnetic_field"), ([
+                             0, 0, 0], "gyro_rotation"),
+                         ([1, 0, 0], "position_pid"), (0,
+                                                       "position_noise"), ([1, 0, 0], "heading_pid")
                          ]
 
         db_initial_new_params = [(Phase.TRAVERSE, "phase"), ([10, 20, 50], "state"), (False, "is_sim"),
                                  (2, "plastic_weight"),
-                                 (98, "battery"), (0.6, "move_dist"), ([4.25, 3.2, 0.1], "acceleration"),
-                                 ([5, 6, 0.3], "magnetic_field"), ([0.5, 0.2, 0.4], "gyro_rotation"),
-                                 ([0.12, 1.7, 9.2], "position_pid"), (0.23, "position_noise"),
+                                 (98, "battery"), (0.6, "move_dist"), ([
+                                     4.25, 3.2, 0.1], "acceleration"),
+                                 ([5, 6, 0.3], "magnetic_field"), ([
+                                     0.5, 0.2, 0.4], "gyro_rotation"),
+                                 ([0.12, 1.7, 9.2], "position_pid"), (0.23,
+                                                                      "position_noise"),
                                  ([9, 0.4, 0.16], "heading_pid")
                                  ]
 
         db_one_new_params = [(Phase.AVOID_OBSTACLE, "phase"), ([0, 0, 0], "state"), (True, "is_sim"), (3, "plastic_weight"),
-                             (46, "battery"), (0.5, "move_dist"), ([0.1, 2.3, 0.3], "acceleration"),
-                             ([0.2, 0.15, 0.3], "magnetic_field"), ([0, 0, 0], "gyro_rotation"),
-                             ([1, 0.5, 0.82], "position_pid"), (0, "position_noise"), ([1, 0, 0], "heading_pid")
+                             (46, "battery"), (0.5, "move_dist"), ([
+                                 0.1, 2.3, 0.3], "acceleration"),
+                             ([0.2, 0.15, 0.3], "magnetic_field"), ([
+                                 0, 0, 0], "gyro_rotation"),
+                             ([1, 0.5, 0.82], "position_pid"), (0,
+                                                                "position_noise"), ([1, 0, 0], "heading_pid")
                              ]
 
         testcases = [(db_new_params, self.db_default), (db_initial_new_params, self.db_initial),
@@ -149,7 +166,8 @@ class TestDataBase(unittest.TestCase):
 
         for expected_ans, database in testcases:
             for (ans, name) in expected_ans:
-                multiple_params = ["state", "acceleration", "magnetic_field", "gyro_rotation", "position_pid", "heading_pid"]
+                multiple_params = ["state", "acceleration", "magnetic_field",
+                                   "gyro_rotation", "position_pid", "heading_pid"]
                 if name in multiple_params:
                     data = database.get_data(name)
                     self.assertEqual(ans[0], data[0], name)


### PR DESCRIPTION
Prior to this PR, our `move_to_target_node` and `turn_to_target_heading` functions weren't integrated with the electrical `motor_controller` code, and so, all movement was simulated. With these changes:
- Robot class is able to call `spin_motors` function with the desired (clamped) linear and angular velocities as parameters
- The motor controller then converts this information into different voltages that should be applied to the left and right motors for desired movement.
- Additionally, we now initialize `motor_controller` in `Robot` rather than `Mission` which enables the above functionality.