### PR TITLE
automate is_sim flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,9 @@ For RF Module, must be operating on Raspberry Pi to run these commands.
 
 1. Enable Serial data transmission from RF Module and raspberry pi
    <sudo raspi-config>
-2. Go to "interfacing options" and select the "Serial" option. Make the login shell accessible. 
+2. Go to "interfacing options" and select the "Serial" option. Make the login shell accessible.
+
+For GUI Module
+
+1. install tkinter
+   brew install python-tk@3.10

--- a/engine/is_raspberrypi.py
+++ b/engine/is_raspberrypi.py
@@ -1,5 +1,5 @@
 import io
-import os
+
 def is_raspberrypi():
     """
     Return True if the current device is a raspberry_pi, False otherwise.
@@ -10,6 +10,3 @@ def is_raspberrypi():
             if 'raspberry pi' in m.read().lower(): return True
     except Exception: pass
     return False
-
-
-print(is_raspberrypi())

--- a/engine/robot.py
+++ b/engine/robot.py
@@ -3,11 +3,13 @@ import math
 from electrical import motor_controller
 from engine.kinematics import integrate_odom, feedback_lin, limit_cmds
 from engine.pid_controller import PID
-# from electrical.motor_controller import MotorController
-# import electrical.gps as GPS 
-# import electrical.imu as IMU 
-# import electrical.radio_module as RadioModule
-# import serial
+from engine.is_raspberrypi import is_raspberrypi
+if is_raspberrypi():
+    from electrical.motor_controller import MotorController
+    import electrical.gps as GPS 
+    import electrical.imu as IMU 
+    import electrical.radio_module as RadioModule
+    import serial
 
 from constants.definitions import CSV_PATH
 
@@ -51,7 +53,7 @@ class Robot:
     heading is in range [0..359]
     """
 
-    def __init__(self, x_pos, y_pos, heading, epsilon, max_v, radius, is_sim=True, position_kp=1, position_ki=0,
+    def __init__(self, x_pos, y_pos, heading, epsilon, max_v, radius, position_kp=1, position_ki=0,
                  position_kd=0, position_noise=0, heading_kp=1, heading_ki=0, heading_kd=0, heading_noise=0,
                  init_phase=1, time_step=1, move_dist=.5, turn_angle=3, plastic_weight=0, use_ekf=False,
                  init_gps=(0, 0), gps_data=(0, 0), imu_data=None, ekf_var=None, gps=None, imu=None, motor_controller=None):
@@ -86,7 +88,7 @@ class Robot:
         """
         self.state = np.array([[x_pos], [y_pos], [heading]])
         self.truthpose = np.transpose(np.array([[x_pos], [y_pos], [heading]]))
-        self.is_sim = is_sim
+        self.is_sim = not is_raspberrypi()
         self.phase = Phase(init_phase)
         self.epsilon = epsilon
         self.max_velocity = max_v
@@ -117,11 +119,11 @@ class Robot:
         self.mc = motor_controller
         self.linear_v = 0
         self.angular_v = 0
-        # if not self.is_sim:
-        #     self.motor_controller = MotorController(self, wheel_radius = 0, vm_load1 = 1, vm_load2 = 1, L = 0, R = 0)
-        #     self.robot_radio_session = RadioModule(serial.Serial('/dev/ttyS0', 57600)) 
-        #     self.gps = GPS(serial.Serial('/dev/ttyACM0', 19200, timeout=5)) 
-        #     self.imu = IMU(busio.I2C(board.SCL, board.SDA)) 
+        if not self.is_sim:
+            self.motor_controller = MotorController(self, wheel_radius = 0, vm_load1 = 1, vm_load2 = 1, L = 0, R = 0)
+            self.robot_radio_session = RadioModule(serial.Serial('/dev/ttyS0', 57600)) 
+            self.gps = GPS(serial.Serial('/dev/ttyACM0', 19200, timeout=5)) 
+            self.imu = IMU(busio.I2C(board.SCL, board.SDA)) 
 
         self.loc_pid_x = PID(
             Kp=self.position_kp, Ki=self.position_ki, Kd=self.position_kd, target=0, sample_time=self.time_step,

--- a/engine/sim_trajectory.py
+++ b/engine/sim_trajectory.py
@@ -12,7 +12,7 @@ from engine.base_station import BaseStation
 from engine.mission import Mission
 from engine.mission import ControlMode
 from engine.database import DataBase
-
+from engine.is_raspberrypi import is_raspberrypi
 import logging
 import threading
 import time
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     '''------------------- MISSION EXECUTION -------------------'''
     global rpi_comms, is_sim
     rpi_comms = True # Set to true when the rpi/robot is communicating w/ the GUI
-    is_sim = True # Set to true when simulating the rpi, set to false when running on rpi
+    is_sim = not is_raspberrypi() # Set to true when simulating the rpi, set to false when running on rpi
     format = "%(asctime)s: %(message)s"
     logging.basicConfig(format=format, level=logging.INFO,
                         datefmt="%H:%M:%S")

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -24,6 +24,7 @@ from matplotlib import animation as animation
 from matplotlib import patches as patch
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 import PySimpleGUI as sg
+from engine.is_raspberrypi import is_raspberrypi
 
 import os
 import math
@@ -38,7 +39,7 @@ import serial
 #################### BEGINNING OF SECTION 1. MATPLOTLIB ROBOT MAPPING ####################
 matplotlib.use('TkAgg')
 # ser = serial.Serial("/dev/tty.usbserial-017543DC", 57600)
-is_sim = True # Change to False when testing RPI to GUI connection
+is_sim = is_raspberrypi() # Change to False when testing RPI to GUI connection
 
 def get_control_mode(window):
     """

--- a/tests/compilation_tests/database_test.py
+++ b/tests/compilation_tests/database_test.py
@@ -13,13 +13,13 @@ Unit tests for database.py
 class TestDataBase(unittest.TestCase):
     # DataBase instances to test on
     robot_default = Robot(x_pos=0, y_pos=0, heading=0, epsilon=0, max_v=0,
-                          radius=0, is_sim=True)
+                          radius=0)
 
     db_default = DataBase(robot_default)
 
     # We can't make is_sim false because it fails GitHub merge tests.
     robot_initial = Robot(x_pos=0, y_pos=0, heading=0, epsilon=0, max_v=0,
-                          radius=0, is_sim=True, plastic_weight=2, move_dist=.6, position_noise=0.23)
+                          radius=0, plastic_weight=2, move_dist=.6, position_noise=0.23)
     robot_initial.position_kp = 0.12
     robot_initial.position_ki = 1.7
     robot_initial.position_kd = 9.2
@@ -32,6 +32,7 @@ class TestDataBase(unittest.TestCase):
     robot_initial.magnetic_field = [0.1, 0.2, 0.3]
     robot_initial.gyro_rotation = [0.5, 0.2, 0.6]
     robot_initial.acceleration = [4.25, 3.2, 0.1]
+    robot_initial.is_sim = False
 
     db_initial = DataBase(robot_initial)
 
@@ -177,8 +178,7 @@ class TestDataBase(unittest.TestCase):
                     self.assertEqual(ans, database.get_data(name), name)
 
     def test_phase_as_value(self):
-        robot_phase = Robot(x_pos= 0, y_pos =0, heading =0, epsilon =0, max_v =0, 
-    radius =0, is_sim=True)
+        robot_phase = Robot(x_pos= 0, y_pos =0, heading =0, epsilon =0, max_v =0, radius =0)
         db_robot_phase = DataBase(robot_phase)
         phases = list(Phase)
         num_phases = len(phases)


### PR DESCRIPTION
<!-- Make sure your PR title above ^ is descriptive (e.g. "Changing color of waypoints on Matplotlib graph of robot simulation") -->

## References
<!-- Add any other external links/references/resources here -->

## Summary
Automate is_sim flag in robot.py, sim_trajectory.py, and gui.py. 
<!-- e.g TLDR: Currently, all the waypoints on our Matplotlib popup graph for our robot simulation are all the same color. 
To differentiate between active and inactive nodes, active nodes will be colored blue and inactive nodes will be colored red.
This will allow the user to visually see where the robot plans to go. -->

### Description
<!-- Add a more detailed description here to give your reviewer context. Relevant screenshots. What changes were made? Why did you decide to implement it this way? etc. -->
is_sim flag is True when the code is running on a simulation and false otherwise. Before this flag is manually set, now this PR automates the flag using is_raspberrypi.py which automatically check is the code is running on a raspberry pi. If the code is running on a raspberry pi, the is_sim flag is False. 

## Test Plan
<!-- How has this been tested? What steps did you take? Please describe in detail how you tested your changes and why it works. -->
check these simulation still works: 
python -m gui.gui 
python -m engine.sim_trajectory 


## Other
<!-- Add any additional details here (e.g. co-authors). Delete this section if this is not relevant. -->

<!-- Please make sure PRs are small. If not, consider breaking up your PR into multiple PRs.
Feel free to delete comments after you are done. -->
