### PR TITLE
Swap EKF Noise Matrices Q and R

### DIFF
--- a/tests/compilation_tests/mag_heading_test.py
+++ b/tests/compilation_tests/mag_heading_test.py
@@ -46,20 +46,20 @@ with open(CSV_PATH + '/imu_360_sample1.csv') as csv_file:
 
 ekf = EKF()
 ekf = EKF(gyr=gyr_data, acc=acc_data, mag=mag_data)
-# print(ekf.Q)
-# print(np.shape(ekf.Q))
-height = np.shape(ekf.Q)[0]
+# print(ekf.R)
+# print(np.shape(ekf.R))
+height = np.shape(ekf.R)[0]
 for i in range(height):
-    top = 2.0 * (ekf.Q[i, 2] * ekf.Q[i, 3] + ekf.Q[i, 0] * ekf.Q[i, 1])
-    bottom = ekf.Q[i, 0] * ekf.Q[i, 0] - ekf.Q[i, 1] * ekf.Q[i, 1] - ekf.Q[i, 2] * ekf.Q[i, 2] + ekf.Q[i, 3] * ekf.Q[
+    top = 2.0 * (ekf.R[i, 2] * ekf.R[i, 3] + ekf.R[i, 0] * ekf.R[i, 1])
+    bottom = ekf.R[i, 0] * ekf.R[i, 0] - ekf.R[i, 1] * ekf.R[i, 1] - ekf.R[i, 2] * ekf.R[i, 2] + ekf.R[i, 3] * ekf.R[
         i, 3]
 
     heading = np.degrees(math.atan2(top, bottom))
 
-    # ekf.Q[i,1] = 0;
-    # ekf.Q[i,3] = 0;
-    # m = math.sqrt(ekf.Q[i,0]*ekf.Q[i,0] + ekf.Q[i,2]*ekf.Q[i,2]);
-    # ekf.Q[i,0] /= m
-    # ekf.Q[i,2] /= m;
-    # heading = np.degrees(2*math.acos(ekf.Q[i,0]));
+    # ekf.R[i,1] = 0;
+    # ekf.R[i,3] = 0;
+    # m = math.sqrt(ekf.R[i,0]*ekf.R[i,0] + ekf.R[i,2]*ekf.R[i,2]);
+    # ekf.R[i,0] /= m
+    # ekf.R[i,2] /= m;
+    # heading = np.degrees(2*math.acos(ekf.R[i,0]));
     # print(heading)


### PR DESCRIPTION
## References
[ EKF Full Code Documentation ](https://docs.google.com/document/d/1U4ov8-be8NQDjB8Fb7kxxulbnkHCoAF7c8RZAqNis8k/edit#)
[ EKF Math from textbook ](https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python/blob/master/11-Extended-Kalman-Filters.ipynb#)

## Summary
The naming and utilization of noise matrices Q and R in our codebase was wrong and inconsistent with the textbook we are following. This PR makes sure our implementation sticks to the right definition for these two matrices:
`Q`: Process noise covariance matrix. This accounts for noise in robot controls (such as physical environment impact on motor calculations).
`R`: Measurement noise covariance matrix. This accounts for noise in GPS and IMU sensors (can be inherent to the sensors).

