### PR TITLE
[Mission Refactoring 1] Abstract Control Mode into it's own file

### DIFF
--- a/engine/control_mode.py
+++ b/engine/control_mode.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+class ControlMode(Enum):
+    """
+    An enumeration of different control modes
+    """
+    LAWNMOWER = 1
+    LAWNMOWER_B = 2
+    LAWNMOWER_A = 3
+    SPIRAL = 4
+    ROOMBA = 5
+    MANUAL = 6
+    STRAIGHT = 7

--- a/engine/grid.py
+++ b/engine/grid.py
@@ -3,6 +3,7 @@ import math
 import numpy
 
 from engine.node import Node
+from engine.control_mode import ControlMode
 import numpy as np
 from engine.kinematics import meters_to_lat, meters_to_long, get_vincenty_x, get_vincenty_y
 from enum import Enum
@@ -778,7 +779,6 @@ class Grid:
                 - starting node is left most node at selected row
                 - ending node right most node at selected row
         """
-        from engine.mission import ControlMode  # import placed here to avoid circular import
         if mode == ControlMode.LAWNMOWER:
             waypoints = self.get_all_lawnmower_waypoints()
         elif mode == ControlMode.LAWNMOWER_B:

--- a/engine/mission.py
+++ b/engine/mission.py
@@ -1,23 +1,9 @@
 from collections import deque
 from engine.robot import Phase
-
+from engine.control_mode import ControlMode
 from engine.kinematics import get_vincenty_x, get_vincenty_y
 from enum import Enum
 from engine.grid import Grid
-
-
-class ControlMode(Enum):
-    """
-    An enumeration of different control modes
-    """
-    LAWNMOWER = 1
-    LAWNMOWER_B = 2
-    LAWNMOWER_GUIDED = 3
-    SPIRAL = 4
-    ROOMBA = 5
-    MANUAL = 6
-    STRAIGHT = 7
-
 
 '''
 Electrical library imports

--- a/engine/sim_trajectory.py
+++ b/engine/sim_trajectory.py
@@ -11,7 +11,7 @@ from engine.robot_state import Robot_State
 from engine.robot import Phase
 from engine.base_station import BaseStation
 from engine.mission import Mission
-from engine.mission import ControlMode
+from engine.control_mode import ControlMode
 from engine.database import DataBase
 from engine.is_raspberrypi import is_raspberrypi
 import logging

--- a/gui/gui.py
+++ b/gui/gui.py
@@ -15,7 +15,7 @@ from gui.gui_popup import *
 from gui.images import get_images
 from gui.robot_data import RobotData
 import gui.retrieve_inputs as retrieve_inputs
-from engine.mission import ControlMode
+from engine.control_mode import ControlMode
 from electrical.radio_module import RadioModule
 
 import matplotlib

--- a/tests/compilation_tests/grid_test.py
+++ b/tests/compilation_tests/grid_test.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 
 from engine.grid import Grid
 from engine.kinematics import get_vincenty_x, get_vincenty_y
-from engine.mission import ControlMode
+from engine.control_mode import ControlMode
 
 '''
 Visualization and unit tests for grid.py

--- a/tests/compilation_tests/robot_test/traverse_standard_test.py
+++ b/tests/compilation_tests/robot_test/traverse_standard_test.py
@@ -6,6 +6,7 @@ from engine.database import DataBase
 from engine.grid import *
 from engine.robot import Robot
 from engine.robot_state import Robot_State
+from engine.control_mode import ControlMode
 from collections import deque
 
 target = [0, 0]
@@ -23,7 +24,7 @@ class TestTraverseStandardFunctions(unittest.TestCase):
 
         allowed_dist_error = 0.5
         grid = Grid(42.444250, 42.444599, -76.483682, -76.483276)
-        grid_mode = "lawn_border"
+        grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
         unvisited_waypoints = r2d2.traverse_standard(waypoints_to_visit, allowed_dist_error, database)
@@ -36,7 +37,7 @@ class TestTraverseStandardFunctions(unittest.TestCase):
 
         allowed_dist_error = 0.5
         grid = Grid(42.444250, 42.444599, -76.483682, -76.483276)
-        grid_mode = "lawn_border"
+        grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
         unvisited_waypoints = r2d2.traverse_standard(waypoints_to_visit, allowed_dist_error, database)
@@ -49,7 +50,7 @@ class TestTraverseStandardFunctions(unittest.TestCase):
 
         allowed_dist_error = 0.65
         grid = Grid(42.444250, 42.444599, -76.483682, -76.483276)
-        grid_mode = "lawn_border"
+        grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
         unvisited_waypoints = r2d2.traverse_standard(waypoints_to_visit, allowed_dist_error, database)
@@ -62,7 +63,7 @@ class TestTraverseStandardFunctions(unittest.TestCase):
 
         allowed_dist_error = 0.5
         grid = Grid(42.444250, 42.444599, -76.483682, -76.483276)
-        grid_mode = "lawn_border"
+        grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
         unvisited_waypoints = r2d2.traverse_standard(waypoints_to_visit, allowed_dist_error, database)
@@ -75,7 +76,7 @@ class TestTraverseStandardFunctions(unittest.TestCase):
 
         allowed_dist_error = 0.5
         grid = Grid(42.444250, 42.444599, -76.483682, -76.483276)
-        grid_mode = "lawn_border"
+        grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
         unvisited_waypoints = r2d2.traverse_standard(waypoints_to_visit, allowed_dist_error, database)

--- a/tests/functionality_tests/obstacle_tracking_test.py
+++ b/tests/functionality_tests/obstacle_tracking_test.py
@@ -4,7 +4,7 @@ from engine.robot import Robot
 from engine.robot_state import Robot_State
 from engine.mission import Mission
 from engine.base_station import BaseStation
-from engine.mission import ControlMode
+from engine.control_mode import ControlMode
 from constants.definitions import ROOT_DIR
 import random
 


### PR DESCRIPTION
<!-- Make sure your PR title above ^ is descriptive (e.g. "Changing color of waypoints on Matplotlib graph of robot simulation") -->

## References
<!-- Add any other external links/references/resources here -->

## Summary
### TLDR: Currently the ControlMode class is in the `mission.py`. Instead, we put it in its own file.
<!-- e.g TLDR: Currently, all the waypoints on our Matplotlib popup graph for our robot simulation are all the same color. 
To differentiate between active and inactive nodes, active nodes will be colored blue and inactive nodes will be colored red.
This will allow the user to visually see where the robot plans to go. -->

### Description
<!-- Add a more detailed description here to give your reviewer context. Relevant screenshots. What changes were made? Why did you decide to implement it this way? etc. -->
ControlMode should be in its own file as it is not specific to just the Mission class (also used in grid for example). This will make `Mission.py` cleaner. Since this enum is moved to a different file, the respective import statements are updated for the new pathing.

## Test Plan
<!-- How has this been tested? What steps did you take? Please describe in detail how you tested your changes and why it works. -->
Ran test cases using `python -m tests.compilation_tests.test_runner`

## Other
<!-- Add any additional details here (e.g. co-authors). Delete this section if this is not relevant. -->
This is the first part of mission refactoring. Note that this is being merged into the branch `mission_refactor_feature`.

List of Mission Refactoring PR's:
[[Mission Refactoring 1] Abstract Control Mode into it's own file ](https://github.com/cornellnexus/src/pull/124)
[[Mission Refactoring 2] Centralize basestation calculations within Basestation Class initialization](https://github.com/cornellnexus/src/pull/125)
[[Mission Refactoring 3] Abstract attributes from Mission into a new class Mission_State](https://github.com/cornellnexus/src/pull/126)
[[Mission Refactoring 4] Centralize sensor attributes within Robot State, initialize in execute_setup](https://github.com/cornellnexus/src/pull/127)
<!-- Please make sure PRs are small. If not, consider breaking up your PR into multiple PRs.
Feel free to delete comments after you are done. -->
