### PR TITLE
[Mission Refactoring 2] Centralize basestation calculations within Basestation Class initialization

### DIFF
--- a/engine/base_station.py
+++ b/engine/base_station.py
@@ -1,24 +1,38 @@
 import math
-
+from engine.kinematics import get_vincenty_x, get_vincenty_y
 
 class BaseStation:
     """
     Contains base-station-specific information.
     """
 
-    def __init__(self, position, heading=math.pi/2, battery=None, plastic_load=None):
+    def __init__(self, coord, grid, heading=math.pi/2, battery=None, plastic_load=None):
         """
         Arguments:
-            position: location of the base station in GPS coordinates in the form (latitude, longitude)
+            coord: location of the base station in GPS coordinates in the form (latitude, longitude)
+            grid: 
+            heading: which direction the base station is facing in terms of unit circle (in radians), by
+                default faces North (angle pi/2)
+            battery: TODO
+            plastic_load: TODO
+        Instance Attributes:
+            coord: location of the base station in GPS coordinates in the form (latitude, longitude)
+            position: location of base station in the Grid coordinate system
             heading: which direction the base station is facing in terms of unit circle (in radians), by
                 default faces North (angle pi/2)
             battery: TODO
             plastic_load: TODO
         """
-        self.position = position
+        self.coord = coord
+        x = get_vincenty_x((grid.lat_min, grid.long_min),
+                            coord)
+        y = get_vincenty_y((grid.lat_min, grid.long_min),
+                            coord)
+        self.position = (x, y)
         self.heading = heading
-        self.battery = battery
-        self.plastic_load = plastic_load
+        self.battery = battery # Replace w/ battery reading
+        self.plastic_load = plastic_load # Replace w/ base station bucket reading (depends on electrical)
+
 
 
 

--- a/tests/functionality_tests/obstacle_tracking_test.py
+++ b/tests/functionality_tests/obstacle_tracking_test.py
@@ -3,7 +3,6 @@ import math
 from engine.robot import Robot
 from engine.robot_state import Robot_State
 from engine.mission import Mission
-from engine.base_station import BaseStation
 from engine.control_mode import ControlMode
 from constants.definitions import ROOT_DIR
 import random


### PR DESCRIPTION
<!-- Make sure your PR title above ^ is descriptive (e.g. "Changing color of waypoints on Matplotlib graph of robot simulation") -->

## References
<!-- Add any other external links/references/resources here -->

## Summary
### TLDR: Move calculations with respect to the basestations location from the Mission Class into the Basestation Class
<!-- e.g TLDR: Currently, all the waypoints on our Matplotlib popup graph for our robot simulation are all the same color. 
To differentiate between active and inactive nodes, active nodes will be colored blue and inactive nodes will be colored red.
This will allow the user to visually see where the robot plans to go. -->

### Description
<!-- Add a more detailed description here to give your reviewer context. Relevant screenshots. What changes were made? Why did you decide to implement it this way? etc. -->
Right now, in `Mission.py`, the following is initialized:
```
        self.base_station_angle = base_station.heading
        self.allowed_docking_pos_error = allowed_docking_pos_error
        x = get_vincenty_x((grid.lat_min, grid.long_min),
                           base_station.position)
        y = get_vincenty_y((grid.lat_min, grid.long_min),
                           base_station.position)
        self.base_station_loc = (x, y)
```
Mission includes redundant attributes like `self.base_station_angle` which is just the heading of the base station parameter. Rather than creating new variables, it would be better to just save the base station instance as an attribute to the mission state. 

Additionally there is the calculation of the location of base station with respect to the Grid coordinate system (aka x,y then loc). I think it would make more sense to centralize the calculation of the base station location within the Base Station class rather than the Mission Class, and access its value through the base station attribute.

While going through the initializations, I noticed it was unused in tests/functionality_tests/obstacle_tracking_test.py and removed the import

## Test Plan
<!-- How has this been tested? What steps did you take? Please describe in detail how you tested your changes and why it works. -->
Ran `python -m tests.compilation_tests.test_runner`

## Other
<!-- Add any additional details here (e.g. co-authors). Delete this section if this is not relevant. -->
This is the second part of mission refactoring. Note that this is being merged into the branch `controlmode_abstract` (the branch for the first PR https://github.com/cornellnexus/src/pull/124).
Note: Updating the initialization of Base Station is done in the third PR https://github.com/cornellnexus/src/pull/126 (since I commited it tg with those changes)
<!-- Please make sure PRs are small. If not, consider breaking up your PR into multiple PRs.
Feel free to delete comments after you are done. -->
List of Mission Refactoring PR's:
[[Mission Refactoring 1] Abstract Control Mode into it's own file ](https://github.com/cornellnexus/src/pull/124)
[[Mission Refactoring 2] Centralize basestation calculations within Basestation Class initialization](https://github.com/cornellnexus/src/pull/125)
[[Mission Refactoring 3] Abstract attributes from Mission into a new class Mission_State](https://github.com/cornellnexus/src/pull/126)
[[Mission Refactoring 4] Centralize sensor attributes within Robot State, initialize in execute_setup](https://github.com/cornellnexus/src/pull/127)