### PR TITLE
[Mission Refactoring 4] Centralize sensor attributes within Robot State, initialize in execute_setup

### DIFF
--- a/engine/mission.py
+++ b/engine/mission.py
@@ -17,7 +17,7 @@ class Mission:
         while self.mission_state.robot.robot_state.phase != Phase.COMPLETE:
             if self.mission_state.robot.robot_state.phase == Phase.SETUP:
                 # TODO: Determine if sensors are part of mission vs robot
-                self.mission_state.robot.execute_setup(self.mission_state.robot_radio_session, self.mission_state.gps, self.mission_state.imu, self.mission_state.motor_controller)
+                self.mission_state.robot.execute_setup()
 
             elif self.mission_state.robot.robot_state.phase == Phase.TRAVERSE:
                 self.mission_state.waypoints_to_visit = self.mission_state.robot.execute_traversal(self.mission_state.waypoints_to_visit,

--- a/engine/mission_state.py
+++ b/engine/mission_state.py
@@ -4,20 +4,6 @@ from engine.control_mode import ControlMode
 from engine.grid import Grid
 from engine.base_station import BaseStation
 
-# TODO: GPS, IMU, RF module and Motor Controller are also re-initialized in robot_state 
-# We should pick whether we want to initialize the attributes here or in robot_state
-# (which is being passed from Mission into robot.execute_setup; sensors are part of mission vs robot)
-'''
-Electrical library imports
-(need these libraries to run mission out of the loop)
-Commented out for simulation testing purposes
-'''
-# from electrical.gps import GPS
-# from electrical.imu import IMU
-# import serial
-# import board
-# import busio
-# import adafruit_lsm9ds1
 
 class Mission_State:
     """
@@ -59,15 +45,6 @@ class Mission_State:
         self.inactive_waypoints = self.grid.get_inactive_waypoints_list()
         self.waypoints_to_visit = deque(self.all_waypoints)
         self.allowed_dist_error = kwargs.get("allowed_dist_error", 0.5)
-        # TODO: Determine if sensors are part of mission vs robot
-        # if not robot.robot_state.is_sim:
-        #     self.gps_serial = serial.Serial('/dev/ttyACM0', 19200, timeout=5) 
-        #     self.robot_radio_serial = serial.Serial('/dev/ttyS0', 57600) #robot radio 
-        #     self.imu_i2c = busio.I2C(board.SCL, board.SDA)
-        #     self.motor_controller = MotorController(wheel_r = 0, vm_load1 = 1, vm_load2 = 1, L = 0, R = 0, is_sim = robot.robot_state.is_sim)
-        #     self.robot_radio_session = RadioSession(self.robot_radio_serial, is_sim = robot.robot_state.is_sim) 
-        #     self.gps = GPS(self.gps_serial, is_sim = robot.robot_state.is_sim) 
-        #     self.imu = IMU(self.imu_i2c, is_sim = robot.robot_state.is_sim) 
         self.allowed_heading_error = kwargs.get("allowed_heading_error", 0.1)
         self.allowed_docking_pos_error = kwargs.get("allowed_docking_pos_error", 0.1)
         self.time_limit = kwargs.get("time_limit",50000)

--- a/engine/robot.py
+++ b/engine/robot.py
@@ -10,6 +10,19 @@ from constants.definitions import *
 from engine.kinematics import integrate_odom, feedback_lin, limit_cmds, get_vincenty_x, get_vincenty_y
 from csv_files.csv_util import write_state_to_csv, write_phase_to_csv
 
+from engine.is_raspberrypi import is_raspberrypi
+if is_raspberrypi():
+    # Electrical library imports
+    from electrical.motor_controller import MotorController
+    import electrical.gps as GPS 
+    import electrical.imu as IMU 
+    import electrical.radio_module as RadioModule
+    import serial
+    import board
+    import busio
+    # import adafruit_lsm9ds1
+    # from engine.sensor_module import SensorModule # IMU + GPS testing
+
 class Robot:
     """
     A class whose objects contain robot-specific information, and methods to execute individual phases.
@@ -230,31 +243,37 @@ class Robot:
         print('pos: ' + str(self.robot_state.state[0:2]))
         print('heading: ' + str(self.robot_state.state[2]))
 
-    def execute_setup(self, radio_session, gps, imu, motor_controller):
-        gps_setup = gps.setup()
-        imu_setup = imu.setup()
-        radio_session.setup_robot()
-        motor_controller.setup(self.robot_state.is_sim)
+    def execute_setup(self):
+        if not self.is_sim:
+            self.robot_state.motor_controller = MotorController(wheel_radius = 0, vm_load1 = 1, vm_load2 = 1, L = 0, R = 0, is_sim = self.is_sim)
+            self.robot_state.robot_radio_session = RadioModule(serial.Serial('/dev/ttyS0', 57600)) 
+            self.robot_state.gps = GPS(serial.Serial('/dev/ttyACM0', 19200, timeout=5), is_sim = self.is_sim) 
+            self.robot_state.imu = IMU(init_i2c = busio.I2C(board.SCL, board.SDA), is_sim = self.is_sim) 
+        
+            gps_setup = self.robot_state.gps.setup()
+            imu_setup = self.robot_state.imu.setup()
+            self.robot_state.radio_session.setup_robot()
+            self.robot_state.motor_controller.setup(self.robot_state.is_sim)
 
-        zone = ENGINEERING_QUAD  # Used for GPS visualization, make it a parameter
-        self.robot_state.init_gps = (gps.get_gps()["long"], gps.get_gps()["lat"])
-        self.robot_state.imu_data = imu.get_gps()
-        x_init, y_init = (0, 0)
-        heading_init = math.degrees(math.atan2(
-            self.robot_state.imu_data["mag"]["y"], self.robot_state.imu_data["mag"]["x"]))
+            zone = ENGINEERING_QUAD  # Used for GPS visualization, make it a parameter
+            self.robot_state.init_gps = (self.robot_state.gps.get_gps()["long"], self.robot_state.gps.get_gps()["lat"])
+            self.robot_state.imu_data = self.robot_state.imu.get_gps()
+            x_init, y_init = (0, 0)
+            heading_init = math.degrees(math.atan2(
+                self.robot_state.imu_data["mag"]["y"], self.robot_state.imu_data["mag"]["x"]))
 
-        # mu is meters from start position (bottom left position facing up)
-        mu = np.array([[x_init], [y_init], [heading_init]])
+            # mu is meters from start position (bottom left position facing up)
+            mu = np.array([[x_init], [y_init], [heading_init]])
 
-        # confidence of mu, set it to high initially b/c not confident, algo brings it down
-        sigma = np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-        self.robot_state.ekf = LocalizationEKF(mu, sigma)
-        self.robot_state.gps = gps
-        self.robot_state.imu = imu
-        self.robot_state.motor_controller = motor_controller
-        if (radio_session.connected and gps_setup and imu_setup):
-            obstacle_avoidance = threading.Thread(target=self.track_obstacle, daemon=True)
-            obstacle_avoidance.start()  # spawn thread to monitor obstacles
+            # confidence of mu, set it to high initially b/c not confident, algo brings it down
+            sigma = np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+            self.robot_state.ekf = LocalizationEKF(mu, sigma)
+
+            if (self.robot_state.radio_session.connected and gps_setup and imu_setup):
+                obstacle_avoidance = threading.Thread(target=self.track_obstacle, daemon=True)
+                obstacle_avoidance.start()  # spawn thread to monitor obstacles
+                self.set_phase(Phase.TRAVERSE)
+        else:
             self.set_phase(Phase.TRAVERSE)
 
     def execute_traversal(self, unvisited_waypoints, allowed_dist_error, base_station_loc, control_mode, time_limit,

--- a/engine/robot_state.py
+++ b/engine/robot_state.py
@@ -1,16 +1,7 @@
 import math
 import numpy as np
 from engine.phase import Phase
-
-# Sensor dependent packages
 from engine.is_raspberrypi import is_raspberrypi
-if is_raspberrypi():
-    from electrical.motor_controller import MotorController
-    import electrical.gps as GPS 
-    import electrical.imu as IMU 
-    import electrical.radio_module as RadioModule
-    import serial
-    # from engine.sensor_module import SensorModule # IMU + GPS testing
 
 class Robot_State:
     """
@@ -162,13 +153,3 @@ class Robot_State:
         self.lb_ultrasonic = kwargs.get("lb_ultrasonic", None)
         self.rf_ultrasonic = kwargs.get("rf_ultrasonic", None)
         self.rb_ultrasonic = kwargs.get("rb_ultrasonic", None)
-
-        # TODO: GPS, IMU, RF module and Motor Controller are also re-initialized in robot.execute_setup
-        # We should pick whether we want to initialize the attributes here or in robot.execute_setup
-        # (which is being passed from Mission, need to whether sensors are part of mission vs robot)
-        if not self.is_sim:
-            self.motor_controller = MotorController(wheel_radius = 0, vm_load1 = 1, vm_load2 = 1, L = 0, R = 0, is_sim = self.is_sim)
-            self.robot_radio_session = RadioModule(serial.Serial('/dev/ttyS0', 57600)) 
-            self.gps = GPS(serial.Serial('/dev/ttyACM0', 19200, timeout=5), is_sim = self.is_sim) 
-            self.imu = IMU(init_i2c = busio.I2C(board.SCL, board.SDA), is_sim = self.is_sim) 
-        


### PR DESCRIPTION
<!-- Make sure your PR title above ^ is descriptive (e.g. "Changing color of waypoints on Matplotlib graph of robot simulation") -->

## References
<!-- Add any other external links/references/resources here -->

## Summary
### TLDR: Currently, we have attributes and initializations for our sensors twice in both `Mission` and `Robot`. The attributes are stored in `Robot_State` and initialized in `execute_setup` to centralize them within a specific robot and initialize them when necessary/relevant.
<!-- e.g TLDR: Currently, all the waypoints on our Matplotlib popup graph for our robot simulation are all the same color. 
To differentiate between active and inactive nodes, active nodes will be colored blue and inactive nodes will be colored red.
This will allow the user to visually see where the robot plans to go. -->

### Description
<!-- Add a more detailed description here to give your reviewer context. Relevant screenshots. What changes were made? Why did you decide to implement it this way? etc. -->
As mentioned in the TLDR ^

So, in order to do this we must remove sensor related attributes and initializations from `Mission` (and those being sent as arguments to `execute_setup`. Then, keep the sensor attributes in `Robot_State`. I decided to move the initialization of the sensor attributes from `Robot_State` to `execute_setup` since
1) The purpose of `execute_setup` is to setup our robot, sensors, and make sure the sensors are setup/working properly. So, I think it makes sense to initialize it + do any additional sensor setup all in one place.
2) There could be an interim period between when we want to initialize our robot and run our mission (whose first phase is setup). For example, we might not be ready to start the mission of traversing the beach, which requires all the sensors. The robot can exist without the sensors being initialized.

## Test Plan
<!-- How has this been tested? What steps did you take? Please describe in detail how you tested your changes and why it works. -->
This would need to be tested in more detail on the robot with all the sensors attached. 

Imo tho I think any sensor initializations in the robot class are be overridden anyways by `execute_setup` in the robot class which is called using the same sensor initializations in Mission, which is initialized after the robot anyways. So, based on this, if there are any issues from this they likely already existed in our current implementation.

Doesn't test these changes but I also,
Ran tests `python -m tests.compilation_tests.test_runner`
Ran `python -m engine.sim_trajectory` to make sure it compiled and nothing changed.

## Other
<!-- Add any additional details here (e.g. co-authors). Delete this section if this is not relevant. -->
This is the fourth and final part of mission refactoring. Note that this is being merged into the branch `mission_state` (the branch for the third PR https://github.com/cornellnexus/src/pull/126).
<!-- Please make sure PRs are small. If not, consider breaking up your PR into multiple PRs.
Feel free to delete comments after you are done. -->
List of Mission Refactoring PR's:
[[Mission Refactoring 1] Abstract Control Mode into it's own file ](https://github.com/cornellnexus/src/pull/124)
[[Mission Refactoring 2] Centralize basestation calculations within Basestation Class initialization](https://github.com/cornellnexus/src/pull/125)
[[Mission Refactoring 3] Abstract attributes from Mission into a new class Mission_State](https://github.com/cornellnexus/src/pull/126)
[[Mission Refactoring 4] Centralize sensor attributes within Robot State, initialize in execute_setup](https://github.com/cornellnexus/src/pull/127)