### PR TITLE
Fixing obstacle avoidance algorithm with setting obstacle avoidance flag

### DIFF
--- a/engine/robot.py
+++ b/engine/robot.py
@@ -131,7 +131,7 @@ class Robot:
         self.robot_state.goal_location = target
         self.loc_pid_x.reset_integral()
         self.loc_pid_y.reset_integral()
-        while distance_away > allowed_dist_error:
+        while (distance_away > allowed_dist_error) and not (self.robot_state.phase == Phase.AVOID_OBSTACLE):
             if self.robot_state.is_sim:
                 # Adding simulated noise to the robot's state based on gaussian distribution
                 self.robot_state.state[0] = np.random.normal(

--- a/engine/robot.py
+++ b/engine/robot.py
@@ -302,7 +302,6 @@ class Robot:
             self.move_to_target_node(
                 curr_waypoint, allowed_dist_error, database)
             unvisited_waypoints.popleft()
-            return unvisited_waypoints
             # TODO: THIS ISNT CORRECT: NEED TO CHECK IF AVOID_OBSTACLE IN move_to_target_node or can also make PID traversal a separate thread and stop the thread when obstacle detected
 
         self.set_phase(Phase.RETURN)

--- a/engine/robot_state.py
+++ b/engine/robot_state.py
@@ -33,8 +33,6 @@ class Robot_State:
             is_sim: False if the physical robot is being used, True otherwise
             should_store_data: False if csv data should not be stored, True otherwise
             phase: the phase of the robot
-            is_roomba_obstacle: True if there's an obstacle detected during roomba traversal
-            is_roomba_traversal: True if we are using roomba traversal
             enable_obstacle_avoidance: False if we want to pause obstacle avoidance
 
             CONSTANTS
@@ -94,8 +92,6 @@ class Robot_State:
         self.is_sim = kwargs.get("is_sim", not is_raspberrypi())
         self.should_store_data = kwargs.get("should_store_data", False)
         self.phase = Phase(kwargs.get("phase", Phase.SETUP))
-        self.is_roomba_obstacle = kwargs.get("is_roomba_obstacle", False)
-        self.is_roomba_traversal = kwargs.get("is_roomba_traversal", False)
         self.enable_obstacle_avoidance = kwargs.get(
             "enable_obstacle_avoidance", True)
 

--- a/engine/robot_state.py
+++ b/engine/robot_state.py
@@ -3,6 +3,7 @@ import numpy as np
 from engine.phase import Phase
 from engine.is_raspberrypi import is_raspberrypi
 
+
 class Robot_State:
     """
     A class containing robot-specific information about the current state of a robot.
@@ -34,6 +35,7 @@ class Robot_State:
             phase: the phase of the robot
             is_roomba_obstacle: True if there's an obstacle detected during roomba traversal
             is_roomba_traversal: True if we are using roomba traversal
+            enable_obstacle_avoidance: False if we want to pause obstacle avoidance
 
             CONSTANTS
             width: width of the robot in cm
@@ -83,9 +85,6 @@ class Robot_State:
             gps:
             imu:
             ekf:
-
-            THREADS
-            track_obstacle_thread
         """
         # TODO: Fill in missing spec for attributes above
 
@@ -97,6 +96,8 @@ class Robot_State:
         self.phase = Phase(kwargs.get("phase", Phase.SETUP))
         self.is_roomba_obstacle = kwargs.get("is_roomba_obstacle", False)
         self.is_roomba_traversal = kwargs.get("is_roomba_traversal", False)
+        self.enable_obstacle_avoidance = kwargs.get(
+            "enable_obstacle_avoidance", True)
 
         # CONSTANTS
         self.width = kwargs.get("width", 700)
@@ -158,7 +159,7 @@ class Robot_State:
         self.ekf = kwargs.get("ekf", None)
 
         self.front_ultrasonic = kwargs.get("front_ultrasonic", None)
-        self.lf_ultrasonic = kwargs.get("lf_ultrasonic",None )
+        self.lf_ultrasonic = kwargs.get("lf_ultrasonic", None)
         self.lb_ultrasonic = kwargs.get("lb_ultrasonic", None)
         self.rf_ultrasonic = kwargs.get("rf_ultrasonic", None)
         self.rb_ultrasonic = kwargs.get("rb_ultrasonic", None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ vincenty==0.1.4
 statistics==1.0.3.5
 PySimpleGui == 4.59.0 #comment this out when running on rpi
 coverage
-numpy==1.21.6
+numpy==1.24.2
 CMake
 wmm2020
 ahrs

--- a/tests/functionality_tests/mission_test.py
+++ b/tests/functionality_tests/mission_test.py
@@ -28,7 +28,7 @@ class MissionTest():
                                 self.mission.gps, self.mission.imu, self.mission.motor_controller)
         # disabled obstacle avoidance thread because if there is an obstacle,
         # the phase would go into obstacle avoidance despite wanting to solely test another phase (like traversal).
-        self.rb_state.track_obstacle_thread.stop()
+        self.rb_state.enable_obstacle_avoidance = False
 
     def test_traverse(self):
         self.r2d2.execute_traversal(self.mission.waypoints_to_visit, self.mission.allowed_dist_error, self.mission.base_station_loc,
@@ -36,7 +36,7 @@ class MissionTest():
 
     def test_avoid_obstacle(self):
         # can only test avoid obstacle by doing one of the other phase and having an obstacle
-        self.rb_state.track_obstacle_thread.start()
+        self.rb_state.enable_obstacle_avoidance = True
         self.r2d2.execute_traversal(self.mission.waypoints_to_visit, self.mission.allowed_dist_error, self.mission.base_station_loc,
                                     self.mission.control_mode, self.mission.time_limit, self.mission.roomba_radius, self.database)
 

--- a/tests/functionality_tests/sensor_physical_testing.py
+++ b/tests/functionality_tests/sensor_physical_testing.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     r2d2 = Robot(rb_state)
     database = DataBase(r2d2)
     r2d2.execute_setup()
-    rb_state.track_obstacle_thread.stop()
+    rb_state.self.rb_state.enable_obstacle_avoidance = False
 
     if test_state == -1:
         print("gps", rb_state.gps.get_gps())


### PR DESCRIPTION
## Summary
Previously, the obstacle detection thread sets a flag to true if there is an obstacle and the mission state checks the flag and update the goal location and phase when the flag is true. Without this, the obstacle detection thread does not know the goal location and cannot update it appropriately. Now, we are changing this so that the goal location is automatically updated and the tracking obstacle thread can automatically change the phase.

### Description
Update goal_location and prev_phase for each fsm state that lead into obstacle avoidance. Added enable_obstacle_avoidance in the obstacle tracking thread to pause the tracking (for turning). Now that we can pause/resume the tracking obstacle thread, we can remove the roomba flags. Added a check for whether we are in obstacle avoidance for move to target node to interupt while loop.

## Test Plan
python -m tests.functionality_tests.obstacle_tracking_test
python -m tests.compilation_tests.test_runner
python -m engine.sim_trajectory