### PR TITLE
Fixing PID traversal bug

### DIFF
--- a/engine/kinematics.py
+++ b/engine/kinematics.py
@@ -21,8 +21,8 @@ def robot_to_global(pose, x_robot, y_robot):
     px = pose[0]
     py = pose[1]
     theta = pose[2]
-    Tgr = np.array([[math.cos(theta), -1 * math.sin(theta), px], \
-                    [math.sin(theta), math.cos(theta), py], \
+    Tgr = np.array([[math.cos(theta), -1 * math.sin(theta), px],
+                    [math.sin(theta), math.cos(theta), py],
                     [0, 0, 1]])
     # DEBUG UPDATE: added [1] to array in order to make it 3x3 times 3x1 rather than 2x1
     # rounding x,y coordinates to make it testable (ex: 4.000000001 --> 4); noise?
@@ -34,7 +34,7 @@ def robot_to_global(pose, x_robot, y_robot):
 def global_to_robot(pose, x_global, y_global):
     """
     Transforms xy_global into robot coordinates. Outputs a [2x1] np array. 
-    
+
     Inputs: 
         pose: robot's current pose (global) [3x1]
         x_global: x coordinate in global frame 
@@ -45,8 +45,8 @@ def global_to_robot(pose, x_global, y_global):
     px = pose[0]
     py = pose[1]
     theta = pose[2]
-    Tgr = np.array([[math.cos(theta), -1 * math.sin(theta), px], \
-                    [math.sin(theta), math.cos(theta), py], \
+    Tgr = np.array([[math.cos(theta), -1 * math.sin(theta), px],
+                    [math.sin(theta), math.cos(theta), py],
                     [0, 0, 1]])
     Trg = np.linalg.inv(Tgr)
     # DEBUG UPDATE: Adjusting parameters to be consistent with first funtion
@@ -66,7 +66,8 @@ def feedback_lin(curr_pose, vx_global, vy_global, epsilon):
     """
     theta = float(curr_pose[2])
     v = vx_global * math.cos(theta) + vy_global * math.sin(theta)
-    w = (-1 / epsilon) * vx_global * math.sin(theta) + (1 / epsilon) * vy_global * math.cos(theta)
+    w = (-1 / epsilon) * vx_global * math.sin(theta) + \
+        (1 / epsilon) * vy_global * math.cos(theta)
     return (v, w)
 
 
@@ -114,9 +115,11 @@ def integrate_odom(pose, d, phi):
         new_y = pose[1] + d * math.sin(pose[2])
         new_theta = pose[2]
     else:
-        new_x = pose[0] + (d / phi) * (math.sin(pose[2] + phi) - math.sin(pose[2]))
-        new_y = pose[1] + (d / phi) * (-math.cos(pose[2] + phi) + math.cos(pose[2]))
-        new_theta = (pose[2] + phi) % (2 * math.pi)
+        new_x = pose[0] + (d / phi) * \
+            (math.sin(pose[2] + phi) - math.sin(pose[2]))
+        new_y = pose[1] + (d / phi) * \
+            (-math.cos(pose[2] + phi) + math.cos(pose[2]))
+        new_theta = pose[2] + phi
         # new_theta = (pose[2] + phi)
     return np.array([[float(new_x)], [float(new_y)], [float(new_theta)]])
 
@@ -127,7 +130,8 @@ def meters_to_gps(lat, long, dy, dx):
     dx meters horizontally (E-W) and dy meters vertically. [N-S]
     """
     new_lat = lat + ((dy / EARTH_RADIUS) * (180 / math.pi)) / 1000
-    new_long = long + ((dx / EARTH_RADIUS) * (180 / math.pi) / math.cos(lat * math.pi / 180))
+    new_long = long + ((dx / EARTH_RADIUS) *
+                       (180 / math.pi) / math.cos(lat * math.pi / 180))
     return new_lat, new_long
 
 
@@ -143,7 +147,8 @@ def meters_to_long(m, latitude):
     """
     Returns an approximation of m meters in units of longitude.
     """
-    long = ((m / EARTH_RADIUS) * (180 / math.pi) / math.cos(latitude * math.pi / 180))
+    long = ((m / EARTH_RADIUS) * (180 / math.pi) /
+            math.cos(latitude * math.pi / 180))
     return long
 
 

--- a/engine/kinematics.py
+++ b/engine/kinematics.py
@@ -120,7 +120,6 @@ def integrate_odom(pose, d, phi):
         new_y = pose[1] + (d / phi) * \
             (-math.cos(pose[2] + phi) + math.cos(pose[2]))
         new_theta = pose[2] + phi
-        # new_theta = (pose[2] + phi)
     return np.array([[float(new_x)], [float(new_y)], [float(new_theta)]])
 
 

--- a/engine/kinematics.py
+++ b/engine/kinematics.py
@@ -119,7 +119,7 @@ def integrate_odom(pose, d, phi):
             (math.sin(pose[2] + phi) - math.sin(pose[2]))
         new_y = pose[1] + (d / phi) * \
             (-math.cos(pose[2] + phi) + math.cos(pose[2]))
-        new_theta = pose[2] + phi
+        new_theta = (pose[2] + phi + math.pi) % (2 * math.pi) - math.pi
     return np.array([[float(new_x)], [float(new_y)], [float(new_theta)]])
 
 

--- a/engine/robot_logic/traversal.py
+++ b/engine/robot_logic/traversal.py
@@ -8,23 +8,25 @@ from engine.kinematics import *
 from engine.robot_logic.robot_helpers import phase_change, calculate_dist
 from csv_files.csv_util import write_state_to_csv
 
+
 def traversal_logic(robot_state, mission_state, database):
-        """
-        Function called by our Mission to start the traversal phase. 
-        Currently we have two different traversal modes, our standard lawn-mower 
-        traversal and our roomba-mode traversal. 
-        """
-        robot_state.prev_phase = Phase.TRAVERSE
-        control_mode = robot_state.control_mode
-        if control_mode == ControlMode.LAWNMOWER:  
-            return traverse_standard(robot_state, mission_state.waypoints_to_visit,
-                                     mission_state.allowed_dist_error, database)
-        elif control_mode == ControlMode.ROOMBA:
-            robot_state.enable_obstacle_avoidance = False
-            traverse_roomba(robot_state, mission_state.base_station_loc,
-                                   mission_state.time_limit, mission_state.roomba_radius)
-            robot_state.enable_obstacle_avoidance = True 
-            return None
+    """
+    Function called by our Mission to start the traversal phase. 
+    Currently we have two different traversal modes, our standard lawn-mower 
+    traversal and our roomba-mode traversal. 
+    """
+    robot_state.prev_phase = Phase.TRAVERSE
+    control_mode = robot_state.control_mode
+    if control_mode == ControlMode.LAWNMOWER:
+        return traverse_standard(robot_state, mission_state.waypoints_to_visit,
+                                 mission_state.allowed_dist_error, database)
+    elif control_mode == ControlMode.ROOMBA:
+        robot_state.enable_obstacle_avoidance = False
+        traverse_roomba(robot_state, mission_state.base_station_loc,
+                        mission_state.time_limit, mission_state.roomba_radius)
+        robot_state.enable_obstacle_avoidance = True
+        return None
+
 
 def traverse_standard(robot_state, unvisited_waypoints, allowed_dist_error, database):
     """ Move the robot by following the traversal path given by [unvisited_waypoints].
@@ -41,12 +43,14 @@ def traverse_standard(robot_state, unvisited_waypoints, allowed_dist_error, data
         # TODO: add return when tank is full, etc
         # Removed function move to target heading since it doesn't really make sense
         robot_state.goal_location = curr_waypoint
-        move_to_target_node(robot_state, curr_waypoint, allowed_dist_error, database)
+        move_to_target_node(robot_state, curr_waypoint,
+                            allowed_dist_error, database)
         unvisited_waypoints.popleft()
-        
+
     robot_state.phase = Phase.RETURN
     phase_change(robot_state)
     return robot_state, unvisited_waypoints
+
 
 def move_to_target_node(robot_state, target, allowed_dist_error, database):
     """
@@ -64,16 +68,33 @@ def move_to_target_node(robot_state, target, allowed_dist_error, database):
     robot_state.goal_location = target
     robot_state.loc_pid_x.reset_integral()
     robot_state.loc_pid_y.reset_integral()
+    using_heading_pid = True
+    simulate = False
+    if simulate:
+        i = 0
+    import matplotlib.pyplot as plt
     while (distance_away > allowed_dist_error) and not (robot_state.phase == Phase.AVOID_OBSTACLE):
         # Error in terms of latitude and longitude, NOT meters
         x_coords_error = target[0] - robot_state.state[0]
         y_coords_error = target[1] - robot_state.state[1]
+        if simulate:
+            i += 1
+            if i == 50:
+                break
+        desired_angle = math.atan2(
+            target[1] - robot_state.state[1], target[0] - robot_state.state[0])
 
         x_vel = robot_state.loc_pid_x.update(x_coords_error)
         y_vel = robot_state.loc_pid_y.update(y_coords_error)
+        if using_heading_pid:
+            turn_to_target_heading(robot_state, desired_angle, 0.01, database)
 
         cmd_v, cmd_w = feedback_lin(
             predicted_state, x_vel, y_vel, robot_state.epsilon)
+
+        if using_heading_pid:
+            cmd_v = np.array([math.sqrt(x_vel**2 + y_vel**2)])
+            cmd_w = np.array([0])
 
         # clamping of velocities:
         (limited_cmd_v, limited_cmd_w) = limit_cmds(
@@ -83,7 +104,8 @@ def move_to_target_node(robot_state, target, allowed_dist_error, database):
 
         robot_state.linear_v = limited_cmd_v[0]
         robot_state.angular_v = limited_cmd_w[0]
-        travel(robot_state, robot_state.time_step * limited_cmd_v[0], robot_state.time_step * limited_cmd_w[0])
+        travel(robot_state, robot_state.time_step *
+               limited_cmd_v[0], robot_state.time_step * limited_cmd_w[0])
         if not robot_state.is_sim:
             robot_state.motor_controller.spin_motors(
                 limited_cmd_w[0], limited_cmd_v[0])
@@ -105,6 +127,18 @@ def move_to_target_node(robot_state, target, allowed_dist_error, database):
 
         # location error (in meters)
         distance_away = calculate_dist(target, predicted_state)
+        if simulate:
+            x = robot_state.truthpose[:, 0]
+            y = robot_state.truthpose[:, 1]
+            plt.scatter(target[0], target[1])
+            plt.text(target[0], target[1], "target")
+    if simulate:
+        for index in range(i):
+            plt.scatter(
+                robot_state.truthpose[:, 0], robot_state.truthpose[:, 1])
+            plt.text(x[index], y[index], index)
+        plt.show()
+
 
 def travel(robot_state, delta_d, delta_phi):
     """
@@ -115,12 +149,16 @@ def travel(robot_state, delta_d, delta_phi):
     """
     # if it is a simulation, we update the robot state directly
     if robot_state.is_sim:
-        robot_state.state = np.round(integrate_odom(robot_state.state, delta_d, delta_phi), 3)
-        robot_state.truthpose = np.append(robot_state.truthpose, np.transpose(robot_state.state), 0)
+        robot_state.state = integrate_odom(
+            robot_state.state, delta_d, delta_phi)
+        robot_state.truthpose = np.append(
+            robot_state.truthpose, np.transpose(robot_state.state), 0)
     # otherwise, we update the robot state using EKF
     else:
-        update_state(robot_state, delta_d/robot_state.time_step, delta_phi/robot_state.time_step)
-        
+        update_state(robot_state, delta_d/robot_state.time_step,
+                     delta_phi/robot_state.time_step)
+
+
 def update_state(robot_state, velocity, omega):
     """
     Updates the state of the robot given the linear velocity (velocity) and angular velocity (omega) of the robot
@@ -130,14 +168,16 @@ def update_state(robot_state, velocity, omega):
     Returns:
         new_state/measurement (Tuple): new x, y, and heading of robot
     """
-    robot_state.gps_data = (robot_state.gps.get_gps()["long"], robot_state.gps.get_gps()["lat"])
-    
+    robot_state.gps_data = (robot_state.gps.get_gps()[
+                            "long"], robot_state.gps.get_gps()["lat"])
+
     robot_state.imu_data = robot_state.imu.get_gps()
 
     x = get_vincenty_x(robot_state.init_gps, robot_state.gps_data)
     y = get_vincenty_y(robot_state.init_gps, robot_state.gps_data)
 
-    heading = math.degrees(math.atan2(robot_state.imu_data["mag"]["y"], robot_state.imu_data["mag"]["x"]))
+    heading = math.degrees(math.atan2(
+        robot_state.imu_data["mag"]["y"], robot_state.imu_data["mag"]["x"]))
 
     measurements = np.array([[x], [y], [heading]])
     if robot_state.using_ekf:
@@ -149,6 +189,7 @@ def update_state(robot_state, velocity, omega):
         new_state = np.array([[new_x], [new_y], [new_heading]])
         return new_state
     return measurements
+
 
 def traverse_roomba(robot_state, base_station_loc, time_limit, roomba_radius):
     """ Move the robot in a roomba-like manner.
@@ -207,39 +248,41 @@ def traverse_roomba(robot_state, base_station_loc, time_limit, roomba_radius):
     return None
 
 
-# JULIE NOTE: I DONT THINK THIS FUNCTION WILL WORK. WE CAN'T TURN IN PLACE. 
+# JULIE NOTE: I DONT THINK THIS FUNCTION WILL WORK. WE CAN'T TURN IN PLACE.
 # I am leaving this here because the obstacle avoidance code currently uses it
 def turn_to_target_heading(robot_state, target_heading, allowed_heading_error, database):
-        """
-        Turns robot in-place to target heading + or - allowed_heading_error, utilizing heading PID.
-        Arguments:
-            target_heading: the heading in radians the robot should approach at the end of in-place rotation.
-            allowed_heading_error: the maximum error in radians a robot can have to target heading while turning in
-                place.
-        """
-        robot_state.enable_obstacle_avoidance = False # we dont want the robot to avoid obstacle here
+    """
+    Turns robot in-place to target heading + or - allowed_heading_error, utilizing heading PID.
+    Arguments:
+        target_heading: the heading in radians the robot should approach at the end of in-place rotation.
+        allowed_heading_error: the maximum error in radians a robot can have to target heading while turning in
+            place.
+    """
+    # we dont want the robot to avoid obstacle here
+    robot_state.enable_obstacle_avoidance = False
+    predicted_state = robot_state.state  # this will come from Kalman Filter
+
+    abs_heading_error = abs(target_heading - float(predicted_state[2]))
+    robot_state.head_pid.reset_integral()
+    while abs_heading_error > allowed_heading_error:
+        theta_error = target_heading - robot_state.state[2]
+        w = robot_state.head_pid.update(theta_error)  # angular velocity
+        _, limited_cmd_w = limit_cmds(
+            0, w, robot_state.max_velocity, robot_state.radius)
+
+        # Get state after movement:
+        predicted_state = robot_state.state  # this will come from Kalman Filter
+        travel(robot_state, 0, robot_state.time_step * limited_cmd_w)
+        if not robot_state.is_sim:
+            robot_state.motor_controller.spin_motors(limited_cmd_w, 0)
+            time.sleep(10)
+
+        # Get state after movement:
         predicted_state = robot_state.state  # this will come from Kalman Filter
 
+        database.update_data(
+            "state", robot_state.state[0], robot_state.state[1], robot_state.state[2])
+
         abs_heading_error = abs(target_heading - float(predicted_state[2]))
-        robot_state.head_pid.reset_integral()
-        while abs_heading_error > allowed_heading_error:
-            theta_error = target_heading - robot_state.state[2]
-            w = robot_state.head_pid.update(theta_error)  # angular velocity
-            _, limited_cmd_w = limit_cmds(
-                0, w, robot_state.max_velocity, robot_state.radius)
-
-            travel(robot_state, 0, robot_state.time_step * limited_cmd_w)
-            if not robot_state.is_sim:
-                robot_state.motor_controller.spin_motors(limited_cmd_w, 0)
-                time.sleep(10)
-
-            # Get state after movement:
-            predicted_state = robot_state.state  # this will come from Kalman Filter
-
-            database.update_data(
-                "state", robot_state.state[0], robot_state.state[1], robot_state.state[2])
-
-            abs_heading_error = abs(target_heading - float(predicted_state[2]))
-        #re-enable after finishing turning 
-        robot_state.enable_obstacle_avoidance = True 
-
+    # re-enable after finishing turning
+    robot_state.enable_obstacle_avoidance = True

--- a/engine/robot_logic/traversal.py
+++ b/engine/robot_logic/traversal.py
@@ -71,28 +71,27 @@ def move_to_target_node(robot_state, target, allowed_dist_error, database):
     using_heading_pid = True
     simulate = False
     if simulate:
-        i = 0
+        iterations = 0
     import matplotlib.pyplot as plt
     while (distance_away > allowed_dist_error) and not (robot_state.phase == Phase.AVOID_OBSTACLE):
         # Error in terms of latitude and longitude, NOT meters
         x_coords_error = target[0] - robot_state.state[0]
         y_coords_error = target[1] - robot_state.state[1]
         if simulate:
-            i += 1
-            if i == 50:
+            iterations += 1
+            if iterations == 50:
                 break
         desired_angle = math.atan2(
             target[1] - robot_state.state[1], target[0] - robot_state.state[0])
 
         x_vel = robot_state.loc_pid_x.update(x_coords_error)
         y_vel = robot_state.loc_pid_y.update(y_coords_error)
-        if using_heading_pid:
-            turn_to_target_heading(robot_state, desired_angle, 0.01, database)
 
         cmd_v, cmd_w = feedback_lin(
             predicted_state, x_vel, y_vel, robot_state.epsilon)
 
         if using_heading_pid:
+            turn_to_target_heading(robot_state, desired_angle, 0.01, database)
             cmd_v = np.array([math.sqrt(x_vel**2 + y_vel**2)])
             cmd_w = np.array([0])
 
@@ -133,7 +132,7 @@ def move_to_target_node(robot_state, target, allowed_dist_error, database):
             plt.scatter(target[0], target[1])
             plt.text(target[0], target[1], "target")
     if simulate:
-        for index in range(i):
+        for index in range(iterations):
             plt.scatter(
                 robot_state.truthpose[:, 0], robot_state.truthpose[:, 1])
             plt.text(x[index], y[index], index)

--- a/engine/robot_logic/traversal.py
+++ b/engine/robot_logic/traversal.py
@@ -61,6 +61,7 @@ def move_to_target_node(robot_state, target, allowed_dist_error, database):
         can be from a node for the robot to have "visited" that node
         database: 
     """
+    import matplotlib.pyplot as plt
     predicted_state = robot_state.state  # this will come from Kalman Filter
 
     # location error (in meters)
@@ -72,7 +73,6 @@ def move_to_target_node(robot_state, target, allowed_dist_error, database):
     simulate = False
     if simulate:
         iterations = 0
-    import matplotlib.pyplot as plt
     while (distance_away > allowed_dist_error) and not (robot_state.phase == Phase.AVOID_OBSTACLE):
         # Error in terms of latitude and longitude, NOT meters
         x_coords_error = target[0] - robot_state.state[0]

--- a/tests/compilation_tests/robot_test/robot_test.py
+++ b/tests/compilation_tests/robot_test/robot_test.py
@@ -44,8 +44,10 @@ class TestNodes(unittest.TestCase):
         new_x = round(-1.3662, 3)
         new_y = round(-0.366198, 3)
         new_theta = round(3 * math.pi / 2, 3)
+        rounded_robot_one_state = [round(state[0], 3)
+                                   for state in self.robot_one.robot_state.state]
         self.assertEqual([[float(new_x)], [float(new_y)], [float(
-            new_theta)]], self.robot_one.robot_state.state.tolist())
+            new_theta)]], rounded_robot_one_state)
         # was move_forward_default
         travel(self.robot_two.robot_state, self.distance, 0)
         new_x = self.robot_two.robot_state.state[0]
@@ -55,15 +57,22 @@ class TestNodes(unittest.TestCase):
             new_theta)]], self.robot_two.robot_state.state.tolist())
         # was test_turn
         travel(self.robot_four.robot_state, 0, math.pi / 2)
-        self.assertEqual([4.712], self.robot_four.robot_state.state[2])
+        rounded_robot_four_state = [round(state[0], 3)
+                                    for state in self.robot_four.robot_state.state]
+        self.assertEqual([4.712], [rounded_robot_four_state[2]])
+        # now that we are no longer clamping heading, below test case doesn't make sense
         # was test_circle_turn
-        original_angle = self.robot_five.robot_state.state[2]
-        travel(self.robot_five.robot_state, 0, math.pi * 2)
-        self.assertEqual([round(original_angle[0], 3)],
-                         self.robot_five.robot_state.state[2])  # added round because travel clamps heading
+        # original_angle = self.robot_five.robot_state.state[2]
+        # travel(self.robot_five.robot_state, 0, math.pi * 2)
+        # rounded_robot_five_state = [round(state[0], 3)
+        #                             for state in self.robot_five.robot_state.state]
+        # self.assertEqual([round(original_angle[0], 3)],
+        #                  rounded_robot_five_state[2])  # added round because travel clamps heading
         # was test_turn_with_time
         travel(self.robot_six.robot_state, 0, math.pi / 2)
-        self.assertEqual([4.712], self.robot_six.robot_state.state[2])
+        rounded_robot_six_state = [round(state[0], 3)
+                                   for state in self.robot_six.robot_state.state]
+        self.assertEqual([4.712], [rounded_robot_six_state[2]])
 
     # TODO: double check the calculations + test doesn't use time
     # def test_move_forward_with_time(self):

--- a/tests/compilation_tests/robot_test/robot_test.py
+++ b/tests/compilation_tests/robot_test/robot_test.py
@@ -1,6 +1,7 @@
 import copy
 import math
 import unittest
+import numpy as np
 
 from engine.robot import Robot
 from engine.robot_logic.traversal import travel
@@ -43,11 +44,9 @@ class TestNodes(unittest.TestCase):
         # Values calculated by hand based on kinematic equations
         new_x = round(-1.3662, 3)
         new_y = round(-0.366198, 3)
-        new_theta = round(3 * math.pi / 2, 3)
-        rounded_robot_one_state = [round(state[0], 3)
-                                   for state in self.robot_one.robot_state.state]
+        new_theta = round(-math.pi / 2, 3)
         self.assertEqual([[float(new_x)], [float(new_y)], [float(
-            new_theta)]], rounded_robot_one_state)
+            new_theta)]], np.round(self.robot_one.robot_state.state, 3).tolist())
         # was move_forward_default
         travel(self.robot_two.robot_state, self.distance, 0)
         new_x = self.robot_two.robot_state.state[0]
@@ -57,22 +56,17 @@ class TestNodes(unittest.TestCase):
             new_theta)]], self.robot_two.robot_state.state.tolist())
         # was test_turn
         travel(self.robot_four.robot_state, 0, math.pi / 2)
-        rounded_robot_four_state = [round(state[0], 3)
-                                    for state in self.robot_four.robot_state.state]
-        self.assertEqual([4.712], [rounded_robot_four_state[2]])
-        # now that we are no longer clamping heading, below test case doesn't make sense
+        self.assertEqual([-math.pi/2], self.robot_four.robot_state.state[2])
         # was test_circle_turn
-        # original_angle = self.robot_five.robot_state.state[2]
-        # travel(self.robot_five.robot_state, 0, math.pi * 2)
-        # rounded_robot_five_state = [round(state[0], 3)
-        #                             for state in self.robot_five.robot_state.state]
-        # self.assertEqual([round(original_angle[0], 3)],
-        #                  rounded_robot_five_state[2])  # added round because travel clamps heading
+        original_angle = self.robot_five.robot_state.state[2]
+        travel(self.robot_five.robot_state, 0, math.pi * 2)
+        rounded_robot_five_state = [round(state[0], 3)
+                                    for state in self.robot_five.robot_state.state]
+        self.assertEqual([round(original_angle[0], 2)],
+                         round(rounded_robot_five_state[2] % math.pi, 2))  # added round because travel clamps heading
         # was test_turn_with_time
         travel(self.robot_six.robot_state, 0, math.pi / 2)
-        rounded_robot_six_state = [round(state[0], 3)
-                                   for state in self.robot_six.robot_state.state]
-        self.assertEqual([4.712], [rounded_robot_six_state[2]])
+        self.assertEqual([-math.pi/2], self.robot_six.robot_state.state[2])
 
     # TODO: double check the calculations + test doesn't use time
     # def test_move_forward_with_time(self):

--- a/tests/compilation_tests/robot_test/traverse_standard_test.py
+++ b/tests/compilation_tests/robot_test/traverse_standard_test.py
@@ -96,11 +96,11 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
         while waypoints_to_visit:
-                r2d2_state, waypoints_to_visit = traverse_standard(
-                    r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+            r2d2_state, waypoints_to_visit = traverse_standard(
+                r2d2_state, waypoints_to_visit, allowed_dist_error, database)
         self.assertEqual(deque([]), waypoints_to_visit)
 
-   def test_different_heading(self):
+    def test_different_heading(self):
         r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi,
                                  epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)

--- a/tests/compilation_tests/robot_test/traverse_standard_test.py
+++ b/tests/compilation_tests/robot_test/traverse_standard_test.py
@@ -5,7 +5,7 @@ import unittest
 from engine.database import DataBase
 from engine.grid import *
 from engine.robot import Robot
-from engine.robot_logic.traversal import traverse_standard
+from engine.robot_logic.traversal import traverse_standard, move_to_target_node
 from engine.robot_state import Robot_State
 from engine.control_mode import ControlMode
 from collections import deque
@@ -15,11 +15,46 @@ add_to_x = False
 gps_noise_range = .3
 
 
-# Takes approx. 9 seconds for 5 tests
-class TestTraverseStandardFunctions(unittest.TestCase):
+class TestMoveToTargetNode(unittest.TestCase):
+    def test1(self):
+        r2d2_state = Robot_State(xpos=42.444250, ypos=-76.483682, heading=0,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2, position_kp=.1, heading_kp=.1, position_kd=0.0, heading_kd=0.0
+                                 )
+        r2d2 = Robot(robot_state=r2d2_state)
+        database = DataBase(r2d2)
 
+        allowed_dist_error = 0.05
+        move_to_target_node(r2d2_state,
+                            (42.444250, -66.483682), allowed_dist_error, database)
+
+    def test2(self):
+        r2d2_state = Robot_State(xpos=42.444250, ypos=-76.483682, heading=math.pi/2,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2, position_kp=.1, heading_kp=.1, position_kd=0.0, heading_kd=0.0
+                                 )
+        r2d2 = Robot(robot_state=r2d2_state)
+        database = DataBase(r2d2)
+
+        allowed_dist_error = 0.5
+        move_to_target_node(r2d2_state,
+                            (52.444750, -76.483682), allowed_dist_error, database)
+
+    def test3(self):
+        r2d2_state = Robot_State(xpos=42.444250, ypos=-76.483682, heading=0,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2, position_kp=.1, heading_kp=.1, position_kd=0.0, heading_kd=0.0
+                                 )
+        r2d2 = Robot(robot_state=r2d2_state)
+        database = DataBase(r2d2)
+        allowed_dist_error = 0.5
+        move_to_target_node(r2d2_state,
+                            (43.444250, -76.483682), allowed_dist_error, database)
+
+# Takes approx. 9 seconds for 5 tests
+
+
+class TestTraverseStandardFunctions(unittest.TestCase):
     def test_init(self):
-        r2d2_state = Robot_State(xpos=0, ypos=0, heading=math.pi / 2, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2) 
+        r2d2_state = Robot_State(xpos=0, ypos=0, heading=math.pi / 2,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -28,11 +63,13 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        r2d2_state, unvisited_waypoints = traverse_standard(
+            r2d2_state, waypoints_to_visit, allowed_dist_error, database)
         self.assertEqual(deque([]), unvisited_waypoints)
 
     def test_different_init_robot_pos(self):
-        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi / 2, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi / 2,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -41,11 +78,13 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        r2d2_state, unvisited_waypoints = traverse_standard(
+            r2d2_state, waypoints_to_visit, allowed_dist_error, database)
         self.assertEqual(deque([]), unvisited_waypoints)
 
     def test_different_allowed_dist(self):
-        r2d2_state = Robot_State(xpos=42,ypos=-76, heading=math.pi / 2, epsilon=0.2, max_velocity=0.5, radius=0.2, phase =2)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi / 2,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -54,11 +93,13 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        r2d2_state, unvisited_waypoints = traverse_standard(
+            r2d2_state, waypoints_to_visit, allowed_dist_error, database)
         self.assertEqual(deque([]), unvisited_waypoints)
 
     def test_different_heading(self):
-        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -67,11 +108,13 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        r2d2_state, unvisited_waypoints = traverse_standard(
+            r2d2_state, waypoints_to_visit, allowed_dist_error, database)
         self.assertEqual(deque([]), unvisited_waypoints)
 
     def test_with_minimal_noise(self):
-        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2, position_noise = 0.05)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi, epsilon=0.2,
+                                 max_velocity=0.5, radius=0.2, phase=2, position_noise=0.05)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -80,7 +123,8 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        r2d2_state, unvisited_waypoints = traverse_standard(
+            r2d2_state, waypoints_to_visit, allowed_dist_error, database)
         self.assertEqual(deque([]), unvisited_waypoints)
 
 

--- a/tests/compilation_tests/robot_test/traverse_standard_test.py
+++ b/tests/compilation_tests/robot_test/traverse_standard_test.py
@@ -95,18 +95,10 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-
-
-<< << << < HEAD
-   r2d2_state, unvisited_waypoints = traverse_standard(
-        r2d2_state, waypoints_to_visit, allowed_dist_error, database)
-    self.assertEqual(deque([]), unvisited_waypoints)
-== == == =
-   while waypoints_to_visit:
-        r2d2_state, waypoints_to_visit = traverse_standard(
-            r2d2_state, waypoints_to_visit, allowed_dist_error, database)
-    self.assertEqual(deque([]), waypoints_to_visit)
->>>>>> > main
+        while waypoints_to_visit:
+                r2d2_state, waypoints_to_visit = traverse_standard(
+                    r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        self.assertEqual(deque([]), waypoints_to_visit)
 
    def test_different_heading(self):
         r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi,


### PR DESCRIPTION
## References
- Documentation: https://docs.google.com/document/d/1w-NiddRpPD56dYxc8AsbNXfKp-4ZWtESaPwqZGfKcz4/edit?usp=sharing

## Summary
- In Kinematics, in integrate_odom(), removed domain constraint of new_theta (which was (-2*pi, 2*pi)
- In traverse_standard_test, added the test cases that gave us the errors
- Changed move_to_target_node to turn towards the desired goal, then have the error be the euclidean distance for moving PID (not turning)
- removed rounding of state

### Description
- When setting angle for heading PID to 0, the robot, when moving, could go from a heading of 0 to 2pi - epsilon for a small epsilon, which causes the robot to turn a full circle to get back to a heading of 0
- Added flag to use heading_pid vs original code; set using_heading_pid to true to use the new logic with turning first before moving
- Added flag to visualize move_to_target_node; set simulate to true to show the visualization

## Test Plan
- python -m tests.compilation_tests.test_runner and checking the visualization