### PR TITLE
Fix traversal algorithm bug

### DIFF
--- a/tests/compilation_tests/robot_test/traverse_standard_test.py
+++ b/tests/compilation_tests/robot_test/traverse_standard_test.py
@@ -19,7 +19,8 @@ gps_noise_range = .3
 class TestTraverseStandardFunctions(unittest.TestCase):
 
     def test_init(self):
-        r2d2_state = Robot_State(xpos=0, ypos=0, heading=math.pi / 2, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2) 
+        r2d2_state = Robot_State(xpos=0, ypos=0, heading=math.pi / 2,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -28,11 +29,14 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
-        self.assertEqual(deque([]), unvisited_waypoints)
+        while waypoints_to_visit:
+            r2d2_state, waypoints_to_visit = traverse_standard(
+                r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        self.assertEqual(deque([]), waypoints_to_visit)
 
     def test_different_init_robot_pos(self):
-        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi / 2, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi / 2,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -41,11 +45,14 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
-        self.assertEqual(deque([]), unvisited_waypoints)
+        while waypoints_to_visit:
+            r2d2_state, waypoints_to_visit = traverse_standard(
+                r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        self.assertEqual(deque([]), waypoints_to_visit)
 
     def test_different_allowed_dist(self):
-        r2d2_state = Robot_State(xpos=42,ypos=-76, heading=math.pi / 2, epsilon=0.2, max_velocity=0.5, radius=0.2, phase =2)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi / 2,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -54,11 +61,14 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
-        self.assertEqual(deque([]), unvisited_waypoints)
+        while waypoints_to_visit:
+            r2d2_state, waypoints_to_visit = traverse_standard(
+                r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        self.assertEqual(deque([]), waypoints_to_visit)
 
     def test_different_heading(self):
-        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi,
+                                 epsilon=0.2, max_velocity=0.5, radius=0.2, phase=2)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -67,11 +77,14 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
-        self.assertEqual(deque([]), unvisited_waypoints)
+        while waypoints_to_visit:
+            r2d2_state, waypoints_to_visit = traverse_standard(
+                r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        self.assertEqual(deque([]), waypoints_to_visit)
 
     def test_with_minimal_noise(self):
-        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi, epsilon=0.2, max_velocity=0.5, radius=0.2, phase = 2, position_noise = 0.05)
+        r2d2_state = Robot_State(xpos=42, ypos=-76, heading=math.pi, epsilon=0.2,
+                                 max_velocity=0.5, radius=0.2, phase=2, position_noise=0.05)
         r2d2 = Robot(robot_state=r2d2_state)
         database = DataBase(r2d2)
 
@@ -80,8 +93,10 @@ class TestTraverseStandardFunctions(unittest.TestCase):
         grid_mode = ControlMode.LAWNMOWER_B
         all_waypoints = grid.get_waypoints(grid_mode)
         waypoints_to_visit = deque(all_waypoints)
-        r2d2_state, unvisited_waypoints = traverse_standard(r2d2_state, waypoints_to_visit, allowed_dist_error, database)
-        self.assertEqual(deque([]), unvisited_waypoints)
+        while waypoints_to_visit:
+            r2d2_state, waypoints_to_visit = traverse_standard(
+                r2d2_state, waypoints_to_visit, allowed_dist_error, database)
+        self.assertEqual(deque([]), waypoints_to_visit)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Traverse_standard previously had a while loop, so even if the robot detects an obstacle and set the avoid obstacle flag, the robot would continue doing traverse_standard until there is no more waypoints left

### Description
- Changed logic for traverse_standard: since we effectively already have a while loop in mission, we can remove the while loop from traverse_standard and have the robot go through all waypoints via mission’s while loop instead
- Updated test cases to reflect new logic
- Added logic for doing obstacle avoidance
- Removed unnecessary comments

## Test Plan
- called `python3 -m tests.compilation_tests.test_runner`