### PR TITLE
Control mode arguments

### DIFF
--- a/engine/control_mode.py
+++ b/engine/control_mode.py
@@ -11,5 +11,4 @@ class ControlMode(Enum):
     LAWNMOWER_A = 3
     SPIRAL = 4
     ROOMBA = 5
-    MANUAL = 6
-    STRAIGHT = 7
+    STRAIGHT = 6

--- a/engine/grid.py
+++ b/engine/grid.py
@@ -861,6 +861,5 @@ class Grid:
             raise Exception("LAWNMOWER_A is currently buggy")
             waypoints = self.get_all_guided_lawnmower_waypoints_adjustable(True)
         else:
-            raise Exception("Invalid ControlMode")
             return []
         return waypoints

--- a/engine/grid.py
+++ b/engine/grid.py
@@ -858,6 +858,7 @@ class Grid:
         elif mode == ControlMode.STRAIGHT:
             waypoints = self.get_straight_line_waypoints(y_start_pct=0.5)
         elif mode == ControlMode.LAWNMOWER_A:
+            # TODO: Fix lawnmower_a; documented in a separate google docs
             raise Exception("LAWNMOWER_A is currently buggy")
             waypoints = self.get_all_guided_lawnmower_waypoints_adjustable(True)
         else:

--- a/engine/grid.py
+++ b/engine/grid.py
@@ -857,7 +857,7 @@ class Grid:
             waypoints = self.get_spiral_waypoints()
         elif mode == ControlMode.STRAIGHT:
             waypoints = self.get_straight_line_waypoints(y_start_pct=0.5)
-        elif mode == ControlMode.LAWNMOWER_GUIDED:
+        elif mode == ControlMode.LAWNMOWER_A:
             waypoints = self.get_all_guided_lawnmower_waypoints_adjustable(True)
         else:
             return []

--- a/engine/grid.py
+++ b/engine/grid.py
@@ -858,7 +858,9 @@ class Grid:
         elif mode == ControlMode.STRAIGHT:
             waypoints = self.get_straight_line_waypoints(y_start_pct=0.5)
         elif mode == ControlMode.LAWNMOWER_A:
+            raise Exception("LAWNMOWER_A is currently buggy")
             waypoints = self.get_all_guided_lawnmower_waypoints_adjustable(True)
         else:
+            raise Exception("Invalid ControlMode")
             return []
         return waypoints

--- a/engine/main.py
+++ b/engine/main.py
@@ -31,15 +31,31 @@ if __name__ == "__main__":
     )  # Let user define if on the pi, otherwise set to True
     r2d2 = Robot(robot_state=r2d2_state)
     database = DataBase(r2d2)  # TODO: Replace w new packet transmission impl
+    init_control_mode = user_args.get("control_mode", None)
+    if init_control_mode == "lawnmower":
+        init_control_mode = ControlMode.LAWNMOWER
+    elif init_control_mode == "lawnmower_a":
+        init_control_mode = ControlMode.LAWNMOWER_A
+    elif init_control_mode == "lawnmower_b":
+        init_control_mode = ControlMode.LAWNMOWER_B
+    elif init_control_mode == "spiral":
+        init_control_mode = ControlMode.SPIRAL
+    elif init_control_mode == "straight":
+        init_control_mode = ControlMode.STRAIGHT
+    elif init_control_mode == "manual":
+        init_control_mode = ControlMode.MANUAL
+    elif init_control_mode == "roomba":
+        init_control_mode = ControlMode.ROOMBA
+    else:
+        raise Exception("Control Mode Undefined")
+
     mission_state = Mission_State(
         robot=r2d2,
         base_station_coord=(
             user_args.get("base_lat", 42.444250),
             user_args.get("base_long", -76.483682),
         ),
-        init_control_mode=ControlMode.LAWNMOWER
-        if user_args.get("control_mode", "lawnmower") == "lawnmower"
-        else ControlMode.ROOMBA,
+        init_control_mode=init_control_mode,
     )
     r2d2_state.control_mode = mission_state.control_mode
     m = Mission(mission_state=mission_state)

--- a/engine/main.py
+++ b/engine/main.py
@@ -42,8 +42,6 @@ if __name__ == "__main__":
         init_control_mode = ControlMode.SPIRAL
     elif init_control_mode == "straight":
         init_control_mode = ControlMode.STRAIGHT
-    elif init_control_mode == "manual":
-        init_control_mode = ControlMode.MANUAL
     elif init_control_mode == "roomba":
         init_control_mode = ControlMode.ROOMBA
     else:

--- a/engine/main.py
+++ b/engine/main.py
@@ -38,9 +38,10 @@ if __name__ == "__main__":
             user_args.get("base_long", -76.483682),
         ),
         init_control_mode=ControlMode.LAWNMOWER
-        if user_args.get("lawnmower", True)
+        if user_args.get("control_mode", "lawnmower") == "lawnmower"
         else ControlMode.ROOMBA,
     )
+    r2d2_state.control_mode = mission_state.control_mode
     m = Mission(mission_state=mission_state)
 
     """------------------- MISSION EXECUTION -------------------"""

--- a/engine/parser.py
+++ b/engine/parser.py
@@ -60,6 +60,21 @@ def parse_main():
         default=-76.483682,
         help="a float for the base stations's longitude coordinate",
     )
+    parser.add_argument(
+        "-c",
+        "--control_mode",
+        type=str,
+        choices=[
+            "lawnmower",
+            "lawnmower_b",
+            "lawnmower_a",
+            "spiral",
+            "roomba",
+            "manual",
+            "straight",
+        ],
+        help="determines initial control mode",
+    )
     # TODO: add flags for different control modes, after fixing which ones we have
     args = parser.parse_args()
     return vars(args)

--- a/engine/parser.py
+++ b/engine/parser.py
@@ -70,7 +70,6 @@ def parse_main():
             "lawnmower_a",
             "spiral",
             "roomba",
-            "manual",
             "straight",
         ],
         help="determines initial control mode",

--- a/engine/plot_trajectory.py
+++ b/engine/plot_trajectory.py
@@ -120,7 +120,7 @@ def plot_sim_traj(m):
         circle = plt.Circle((init_x, init_y), m.mission_state.roomba_radius)
         ax.add_patch(circle)
 
-    elif m.mission_state.control_mode != ControlMode.MANUAL:
+    else:
         active_nodes = waypoints_to_array(m.mission_state.active_waypoints)
         inactive_nodes = waypoints_to_array(m.mission_state.inactive_waypoints)
         ax.plot(active_nodes[:, 0], active_nodes[:, 1], "bx")

--- a/engine/robot_logic/traversal.py
+++ b/engine/robot_logic/traversal.py
@@ -27,9 +27,7 @@ def traversal_logic(robot_state, mission_state, database):
             database,
         )
         robot_state.enable_obstacle_avoidance = True
-        return None
-    elif control_mode == ControlMode.MANUAL or control_mode == ControlMode.LAWNMOWER_A:
-        print("MANUAL MODE IS UNIMPLEMENTED; LAWNMOWER_A IS BUGGY")
+        return robot_state, None
     else:
         return traverse_standard(
             robot_state,

--- a/engine/robot_logic/traversal.py
+++ b/engine/robot_logic/traversal.py
@@ -17,14 +17,7 @@ def traversal_logic(robot_state, mission_state, database):
     """
     robot_state.prev_phase = Phase.TRAVERSE
     control_mode = robot_state.control_mode
-    if control_mode == ControlMode.LAWNMOWER:
-        return traverse_standard(
-            robot_state,
-            mission_state.waypoints_to_visit,
-            mission_state.allowed_dist_error,
-            database,
-        )
-    elif control_mode == ControlMode.ROOMBA:
+    if control_mode == ControlMode.ROOMBA:
         robot_state.enable_obstacle_avoidance = False
         traverse_roomba(
             robot_state,
@@ -34,6 +27,15 @@ def traversal_logic(robot_state, mission_state, database):
         )
         robot_state.enable_obstacle_avoidance = True
         return None
+    elif control_mode == ControlMode.MANUAL or control_mode == ControlMode.LAWNMOWER_A:
+        print("MANUAL MODE IS UNIMPLEMENTED; LAWNMOWER_A IS BUGGY")
+    else:
+        return traverse_standard(
+            robot_state,
+            mission_state.waypoints_to_visit,
+            mission_state.allowed_dist_error,
+            database,
+        )
 
 
 def traverse_standard(robot_state, unvisited_waypoints, allowed_dist_error, database):


### PR DESCRIPTION
## Summary
- Added arguments for simulating different control modes

### Description
- Removed Manual Mode
- Added arguments for each control mode
- Found and documented bug for lawnmower_a
- Fixed logic for traversal.py

## Test Plan
- Ran `python3 -m tests.compilation_tests.test_runner`
- Ran `python3 -m engine.main -c <control_mode>`, where <control_mode> can be any of the lawnmower; lawnmower_a currently has a bug that is documented [here](https://docs.google.com/document/d/1UFHlF7Cpsu6p8-Y4yFsp4MvsbpT_L_TX-7Lgku4upcE/edit?usp=sharing)