### PR TITLE
Added barebones class for parsing data from serial port for gps

### DIFF
--- a/electrical/calibrate_mag_gyro.py
+++ b/electrical/calibrate_mag_gyro.py
@@ -70,7 +70,7 @@ def magnetometer_calibrate():
 
     # could maybe automate when we detect that the hard offset values stop changing
     print("Magnetometer Calibration")
-    print("Start moving the board in all directions")
+    print("Start SLOWLY moving the board in all directions")
     print("When the magnetic Hard Offset values stop")
     print("changing, press ENTER to go to the next step")
     print("Press ENTER to continue...")
@@ -94,7 +94,6 @@ def magnetometer_calibrate():
         min_x = min(min_x, mag_x)
         min_y = min(min_y, mag_y)
         min_z = min(min_z, mag_z)
-
         max_x = max(max_x, mag_x)
         max_y = max(max_y, mag_y)
         max_z = max(max_z, mag_z)
@@ -105,9 +104,15 @@ def magnetometer_calibrate():
         HI_offset_z = (max_z + min_z) / 2
 
         # Get the soft-iron offset values
-        SI_offset_x = (max_x - min_x) / 2
-        SI_offset_y = (max_y - min_y) / 2
-        SI_offset_z = (max_z - min_z) / 2
+        mag_scale_x = (max_x - min_x) / 2
+        mag_scale_y = (max_y - min_y) / 2
+        mag_scale_z = (max_z - min_z) / 2
+
+        avg_rad = (mag_scale_x + mag_scale_y + mag_scale_z) / 3.0
+
+        SI_offset_x = avg_rad/(mag_scale_x)
+        SI_offset_y = avg_rad/(mag_scale_y)
+        SI_offset_z = avg_rad/(mag_scale_z)
 
         print(
             "Hard-Iron Offset:  X: {0:8.2f}, Y:{1:8.2f}, Z:{2:8.2f} uT".format(
@@ -134,6 +139,8 @@ def magnetometer_calibrate():
             SI_offset_x, SI_offset_y, SI_offset_z
         )
     )
+
+    return hard_off, soft_off
 
     #########################
     # Gyroscope Calibration #
@@ -182,6 +189,7 @@ def gyro_calibrate():
         noise_y = max_y - min_y
         noise_z = max_z - min_z
 
+
         print(
             "Zero Rate Offset:  X: {0:8.2f}, Y:{1:8.2f}, Z:{2:8.2f} rad/s".format(
                 offset_x, offset_y, offset_z
@@ -201,3 +209,7 @@ def gyro_calibrate():
             offset_x, offset_y, offset_z
         )
     )
+
+
+while True:
+    magnetometer_calibrate()

--- a/electrical/gps_nmea_parsing.py
+++ b/electrical/gps_nmea_parsing.py
@@ -1,0 +1,34 @@
+import serial
+import pynmea2
+
+
+"""
+This code is mainly for extracting pure longitude and latitude data from
+a the serial port our ublox C099-F9P gps reciever is connected to.
+
+Note that the C099-F9P module MUST be configured to output NMEA messages,
+which may be of type GGC, RMC, etc.  
+More on GPS messaging protocol can be read here: https://cdn.sparkfun.com/assets/f/7/4/3/5/PM-15136.pdf
+"""
+
+class GPSSerialReader:
+
+    def __init__(self, port, br):
+        # port is the physical port that the GPS module is plugged into on board
+        # port starts at 0, on linux is of form '/dev/ttyS*' where * is the number referring to port
+        self.port = port
+        # higher baud rate is usually better for more accurate positioning
+        self.baud_rate = br
+
+
+    def read_serial(self):
+        with serial.Serial(self.port, self.baud_rate, timeout=1) as ser:
+            while True:
+                line = ser.readline().decode('ascii', errors='replace')
+                if line.startswith('$G'):
+                    try:
+                        msg = pynmea2.parse(line)
+                        # Assuming the message is of type GGA or RMC which contains lat/long
+                        print(f"Latitude: {msg.latitude}, Longitude: {msg.longitude}")
+                    except pynmea2.ParseError as e:
+                        print(f"Parse error: {e}")


### PR DESCRIPTION
Summary: Using u-center, electrical + me and Vinny confirmed the GPS modules to work. Running u-center directly on the RPi is not feasible, so we need a way to retrieve the data from the modules without another application. This would be done through reading the serial port directly.

Description: This class should be built upon in the future. As of right now, our plan is to see if directly reading from serial port(with no 3rd party/u center app) on the RPi is possible, and use that GPS data for our needs in navigation. Further progress should be made with ROS and integrating into the MVP in mind.

For ROS: this would need to be wrapped in a node to broadcast positional data to other nodes.

Test Plan: need to run this on a RPi connect to GPS client to see if long/lat are retrieved.
